### PR TITLE
Use new IO style to fix compilation error

### DIFF
--- a/src/main/scala/SCR.scala
+++ b/src/main/scala/SCR.scala
@@ -1,7 +1,8 @@
 package testchipip
 
-import Chisel._
-import uncore.tilelink._
+import chisel3._
+import chisel3.util._
+import uncore.tilelink.{ClientUncachedTileLinkIO, Grant}
 import cde.Parameters
 import scala.collection.mutable.ListBuffer
 import scala.collection.mutable.HashMap
@@ -19,11 +20,11 @@ class SCRFile(
   val nControl = controlNames.size
   val nStatus = statusNames.size
 
-  val io = new Bundle {
+  val io = IO(new Bundle {
     val tl = (new ClientUncachedTileLinkIO).flip
-    val control = Vec(nControl, UInt(OUTPUT, width = scrDataBits))
-    val status  = Vec(nStatus,  UInt(INPUT, width = scrDataBits))
-  }
+    val control = Output(Vec(nControl, UInt(scrDataBits.W)))
+    val status  = Input( Vec(nStatus,  UInt(scrDataBits.W)))
+  })
 
   val controlMapping = controlNames.zipWithIndex.toMap
   val statusMapping = statusNames.zipWithIndex.toMap

--- a/src/main/scala/Util.scala
+++ b/src/main/scala/Util.scala
@@ -9,10 +9,10 @@ import uncore.tilelink._
 import cde.Parameters
 
 class ResetSync(c: Clock, lat: Int = 2) extends Module(_clock = c) {
-  val io = new Bundle {
-    val reset = Bool(INPUT)
-    val reset_sync = Bool(OUTPUT)
-  }
+  val io = IO(new Bundle {
+    val reset = Input(Bool())
+    val reset_sync = Output(Bool())
+  })
   io.reset_sync := ShiftRegister(io.reset,lat)
 }
 
@@ -28,9 +28,9 @@ object ResetSync {
 // As WideCounter, but it's a module so it can take arbitrary clocks
 class WideCounterModule(w: Int, inc: UInt = UInt(1), reset: Boolean = true, clockSignal: Clock = null, resetSignal: Bool = null)
     extends Module(Option(clockSignal), Option(resetSignal)) {
-  val io = new Bundle {
-    val value = UInt(OUTPUT, width = w)
-  }
+  val io = IO(new Bundle {
+    val value = Output(UInt(width = w))
+  })
   io.value := WideCounter(w, inc, reset)
 }
 


### PR DESCRIPTION
Use the new IO style. If you don't like this (because e.g. you're on an old version of chisel3) this should be written in compatibility mode.