### PR TITLE
Adding FireSim management device for FireChip

### DIFF
--- a/csrc/SimFSimManager.cc
+++ b/csrc/SimFSimManager.cc
@@ -1,0 +1,37 @@
+#include <vpi_user.h>
+#include <svdpi.h>
+
+#include "fsim-manager.h"
+
+FSimManager *dev = NULL;
+
+extern "C" void fsim_manager_init()
+{
+	dev = new FSimManager();
+}
+
+extern "C" void fsim_manager_tick(
+		unsigned char req_valid,
+		unsigned char *req_ready,
+		unsigned int req_bits_query,
+
+		unsigned char *resp_valid,
+		unsigned char resp_ready,
+		unsigned int                    *resp_bits_data)
+{
+	if(dev == NULL) {
+		*req_ready = 0;
+		*resp_valid = 0;
+		return;
+	}
+
+	dev->tick(
+			req_valid,
+			req_bits_query,
+			resp_ready);
+	dev->switch_to_host();
+
+	*req_ready = dev->req_ready();
+	*resp_valid = dev->resp_valid();
+	*resp_bits_data = dev->resp_data();
+}

--- a/csrc/fsim-manager.cc
+++ b/csrc/fsim-manager.cc
@@ -1,0 +1,70 @@
+#include "fsim-manager.h"
+#include <stdlib.h>
+#include <string.h>
+#include <inttypes.h>
+#include <time.h>
+
+void FSimManager::host_thread(void *arg)
+{
+	FSimManager* dev = static_cast<FSimManager*>(arg);
+	dev->run();
+
+	while (true)
+		dev->target->switch_to();
+}
+
+FSimManager::FSimManager()
+{
+	request = 0;
+	responded = false;
+	response = 0;
+	target = context_t::current();
+	host.init(host_thread, this);
+}
+
+FSimManager::~FSimManager()
+{
+}
+
+void FSimManager::tick(
+		uint8_t req_valid,
+		uint32_t req_bits_query,
+		uint8_t resp_ready)
+{
+	if( resp_valid() && resp_ready ) {
+		responded = false;
+	}
+
+	if( req_valid && req_ready() ) {
+		request = req_bits_query;
+	}
+
+}
+
+#define FSIM_REQ_TIME      1
+
+#define FSIM_RESP_ERROR			-1
+#define FSIM_RESP_NOP				0
+void FSimManager::run()
+{
+	while (true) {
+		if( request ) {
+			switch(request){
+				case FSIM_REQ_TIME:
+					{
+						response = time (NULL);
+						responded = true;
+						request = 0;
+						break;
+					}
+				default:
+					{
+						response = FSIM_RESP_ERROR;
+						responded = true;
+						request = 0;
+					}
+			}
+		}
+		this->target->switch_to();
+	}
+}

--- a/csrc/fsim-manager.h
+++ b/csrc/fsim-manager.h
@@ -1,0 +1,31 @@
+#include <stdio.h>
+#include <fesvr/context.h>
+#include <queue>
+
+class FSimManager {
+	public:
+		FSimManager();
+		~FSimManager();
+		void tick(
+				uint8_t req_valid,
+				uint32_t req_bits_query,
+				uint8_t resp_ready);
+
+		bool req_ready() { return true; }
+		bool resp_valid() { return responded; }
+		uint32_t resp_data() { return response; }
+
+		void switch_to_host() { host.switch_to(); }
+	private:
+		// record time here
+		uint32_t request;
+		bool responded;
+		uint32_t response;
+
+		// to run host
+		static void host_thread(void *arg);
+		void run(void);
+
+		context_t* target;
+		context_t host;
+};

--- a/src/main/scala/FSimManager.scala
+++ b/src/main/scala/FSimManager.scala
@@ -8,7 +8,6 @@ import freechips.rocketchip.coreplex.CacheBlockBytes
 import freechips.rocketchip.coreplex.{HasSystemBus, HasPeripheryBus}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.regmapper.{RegisterReadIO,RegisterWriteIO ,RegField, HasRegMap}
-import freechips.rocketchip.rocket.PAddrBits
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.util.{ParameterizedBundle, DecoupledHelper, UIntIsOneOf}
 import scala.math.max
@@ -83,8 +82,8 @@ trait HasPeripheryFSimManagerModuleImp extends LazyMultiIOModuleImp {
   val reset: Bool
   val fsim = IO(new FSimManagerIO)
 
+
   fsim <> outer.fsimman.module.io.ext
-  
   
   def connectSimFSimManager() {
     val sim = Module(new SimFSimManager)

--- a/src/main/scala/WallClock.scala
+++ b/src/main/scala/WallClock.scala
@@ -1,0 +1,84 @@
+package testchipip
+
+import chisel3._
+import chisel3.core.IntParam
+import chisel3.util._
+import freechips.rocketchip.config.{Field, Parameters}
+import freechips.rocketchip.coreplex.CacheBlockBytes
+import freechips.rocketchip.coreplex.{HasSystemBus, HasPeripheryBus}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.regmapper.{RegisterReadIO,RegisterWriteIO ,RegField, HasRegMap}
+import freechips.rocketchip.rocket.PAddrBits
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.util.{ParameterizedBundle, DecoupledHelper, UIntIsOneOf}
+import scala.math.max
+
+class WallClockIO extends Bundle {
+  val req = Decoupled(UInt(32.W))
+  val resp = Flipped(Decoupled(UInt(32.W)))
+}
+
+case class WallClockControllerParams(address: BigInt, beatBytes: Int)
+
+trait WallClockControllerBundle extends Bundle {
+  val ext = new WallClockIO
+}
+
+trait WallClockControllerModule extends Module with HasRegMap {
+  val io: WallClockControllerBundle
+
+  //val query = Reg(Bool())
+  //val query = Reg(UInt(32.W))
+  val requestQueue = Module(new Queue(UInt(32.W),10))
+  val responseQueue = Module(new Queue(UInt(32.W),10))
+
+  //val data = Reg(UInt(32.W))
+  //val allocRead = Wire(new RegisterReadIO(UInt(32.W)))
+  
+  io.ext.req <> requestQueue.io.deq
+  responseQueue.io.enq <> io.ext.resp
+
+  regmap(
+    0x00 -> Seq(RegField.w(32, requestQueue.io.enq)),
+    0x04 -> Seq(RegField.r(32, responseQueue.io.deq)))
+
+}
+
+class WallClockController(c: WallClockControllerParams)(implicit p: Parameters)
+  extends TLRegisterRouter(
+    c.address, "wallclock", Seq("ucbbar,wallclock"),
+    interrupts = 0, beatBytes = c.beatBytes)(
+      new TLRegBundle(c, _)     with WallClockControllerBundle)(
+      new TLRegModule(c, _, _)  with WallClockControllerModule)
+
+class SimWallClock extends BlackBox {
+  val io = IO(new Bundle {
+    val clock = Input(Clock())
+    val reset = Input(Bool())
+    val wclk = Flipped(new WallClockIO)
+  })
+}
+
+trait HasPeripheryWallClock extends HasSystemBus {
+  private val address = BigInt(0x10017000)
+  val wallclock = LazyModule(new WallClockController(WallClockControllerParams(address, sbus.beatBytes)))
+
+  wallclock.node := sbus.toVariableWidthSlaves
+}
+
+trait HasPeripheryWallClockModuleImp extends LazyMultiIOModuleImp {
+  val outer: HasPeripheryWallClock
+  val clock: Clock
+  val reset: Bool
+  val wclk = IO(new WallClockIO)
+
+  wclk <> outer.wallclock.module.io.ext
+  
+  
+  def connectSimWallClock() {
+    val sim = Module(new SimWallClock)
+    sim.io.clock := clock
+    sim.io.reset := reset
+    sim.io.wclk <> wclk
+  }
+}

--- a/vsrc/SimFSimManager.v
+++ b/vsrc/SimFSimManager.v
@@ -1,0 +1,64 @@
+import "DPI-C" function void fsim_manager_init();
+
+import "DPI-C" function void fsim_manager_tick
+(
+	input   bit req_valid,
+	output  bit req_ready,
+	input     int req_bits,
+	output  bit     resp_valid,
+	input           bit resp_ready,
+	output  int     resp_bits
+);
+
+`define RESP_BITS       32
+`define REQ_BITS        32
+
+module SimFSimManager (
+	input           clock,
+	input           reset,
+	input           fsim_req_valid,
+	output  fsim_req_ready,
+	input           [`REQ_BITS-1:0] fsim_req_bits,
+
+	output  fsim_resp_valid,
+	input           fsim_resp_ready,
+	output[`RESP_BITS-1:0]  fsim_resp_bits
+);
+
+bit __req_ready;
+bit __resp_valid;
+int     __resp_bits;
+
+reg __req_ready_reg;
+reg __resp_valid_reg;
+reg [`RESP_BITS-1:0] __resp_bits_reg;
+
+assign fsim_req_ready = __req_ready_reg;
+assign fsim_resp_valid = __resp_valid_reg;
+assign fsim_resp_bits = __resp_bits_reg;
+
+initial begin
+	fsim_manager_init();
+end
+
+always @(posedge clock) begin
+	if(reset) begin
+		__req_ready_reg <= 0;
+		__resp_valid_reg <= 0;
+		__resp_bits_reg <= 0;
+	end else begin
+		fsim_manager_tick(
+			fsim_req_valid,
+			__req_ready,
+			fsim_req_bits,
+
+			__resp_valid,
+			fsim_resp_ready,
+			__resp_bits);
+
+		__req_ready_reg <= __req_ready;
+		__resp_valid_reg <= __resp_valid;
+		__resp_bits_reg <= __resp_bits;
+	end
+end
+endmodule


### PR DESCRIPTION
Hi,
I added FireSim management device FSimManager.
This device simply forwards 32-bit regmapped requests to host, and get 32-bit responses back.
This should not be included in a real chip; this is only for FireChip.
Should mege with master in the future.
Please comment.