### PR TITLE
Scala 2.12 build.sbt fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 /lib
+project/

--- a/build.sbt
+++ b/build.sbt
@@ -5,3 +5,5 @@ version := "1.0"
 name := "testchipip"
 
 scalaVersion := "2.12.4"
+
+scalacOptions += "-Xsource:2.11"


### PR DESCRIPTION
This is needed to build when testchipip is built outside of rocket-chip.