### PR TITLE
Fix PRIx64 problem with certain gcc versions

### DIFF
--- a/csrc/blkdev.cc
+++ b/csrc/blkdev.cc
@@ -1,7 +1,7 @@
 #include "blkdev.h"
-#include <stdlib.h>
-#include <string.h>
-#include <inttypes.h>
+#include <cstdlib>
+#include <cstring>
+#include <cinttypes>
 
 void BlockDevice::host_thread(void *arg)
 {

--- a/csrc/blkdev.h
+++ b/csrc/blkdev.h
@@ -1,8 +1,8 @@
 #include <vector>
 #include <queue>
-#include <stdio.h>
+#include <cstdlib>
 #include <fesvr/context.h>
-#include <stdint.h>
+#include <cstdint>
 
 #define SECTOR_SIZE 512
 #define SECTOR_SHIFT 9


### PR DESCRIPTION
This fixes a problem I'm seeing with gcc versions on the BWRC machines and inttypes.h.