### PR TITLE
Update TLError parameterization

### DIFF
--- a/src/main/scala/Unittests.scala
+++ b/src/main/scala/Unittests.scala
@@ -4,7 +4,7 @@ import chisel3._
 import chisel3.util._
 import freechips.rocketchip.config.Parameters
 import freechips.rocketchip.diplomacy._
-import freechips.rocketchip.devices.tilelink.{TLTestRAM, TLROM, TLError, ErrorParams}
+import freechips.rocketchip.devices.tilelink.{DevNullParams, TLTestRAM, TLROM, TLError}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.unittest._
 import freechips.rocketchip.util._
@@ -317,8 +317,8 @@ class SwitcherTest(implicit p: Parameters) extends LazyModule {
     inChannels, Seq(1, outChannels), Seq(address),
     beatBytes = beatBytes, lineBytes = lineBytes, idBits = outIdBits))
 
-  val error = LazyModule(new TLError(ErrorParams(
-    Seq(address), beatBytes, lineBytes), beatBytes))
+  val error = LazyModule(new TLError(
+    DevNullParams(Seq(address), beatBytes, lineBytes), beatBytes))
 
   val rams = Seq.fill(outChannels) {
     LazyModule(new TLTestRAM(


### PR DESCRIPTION
It seems [this PR](https://github.com/freechipsproject/rocket-chip/commit/4d6d00022a7e4aeb72c743d63ad08f7f554b5304#diff-82be58f573c5e8ae0cea94c7a2a44b40) changed how TLError works.