### PR TITLE
Don't do anything special with simserial args

### DIFF
--- a/src/main/resources/testchipip/csrc/SimSerial.cc
+++ b/src/main/resources/testchipip/csrc/SimSerial.cc
@@ -6,27 +6,6 @@
 
 tsi_t *tsi = NULL;
 
-static inline int copy_argv(int argc, char **argv, char **new_argv)
-{
-    int optind = 1;
-    int new_argc = argc;
-
-    new_argv[0] = argv[0];
-
-    for (int i = 1; i < argc; i++) {
-        if (argv[i][0] != '+') {
-            optind = i - 1;
-            new_argc = argc - i + 1;
-            break;
-        }
-    }
-
-    for (int i = 1; i < new_argc; i++)
-        new_argv[i] = argv[i + optind];
-
-    return new_argc;
-}
-
 extern "C" int serial_tick(
         unsigned char out_valid,
         unsigned char *out_ready,
@@ -45,10 +24,7 @@ extern "C" int serial_tick(
         if (!vpi_get_vlog_info(&info))
           abort();
 
-        char **argv = (char **) malloc(sizeof(char*) * info.argc);
-        int argc = copy_argv(info.argc, info.argv, argv);
-
-        tsi = new tsi_t(argc, argv);
+        tsi = new tsi_t(info.argc, info.argv);
     }
 
     tsi->tick(out_valid, out_bits, in_ready);


### PR DESCRIPTION
Fesvr handles this now so just pass on the plusargs and
they will be correctly ignored
Fixes #34