### PR TITLE
Fix periodchecker to not use timescale

### DIFF
--- a/src/main/resources/testchipip/vsrc/ClockUtil.v
+++ b/src/main/resources/testchipip/vsrc/ClockUtil.v
@@ -93,12 +93,21 @@ module PeriodMonitor #(
     input enable
 );
 
+`ifndef VERILATOR
     time edgetime = 1ps;
+`else
+    time edgetime = 1;
+`endif
     time period;
 
     always @(posedge clock) begin
+`ifndef VERILATOR
         period = $time/1ps - edgetime;
         edgetime = $time/1ps;
+`else
+        period = $time - edgetime;
+        edgetime = $time;
+`endif
         if (period > 0) begin
             if (enable && (period < minperiodps)) begin
                 $display("PeriodMonitor detected a small period of %d ps at time %0t", period, $time);

--- a/src/main/resources/testchipip/vsrc/ClockUtil.v
+++ b/src/main/resources/testchipip/vsrc/ClockUtil.v
@@ -85,21 +85,20 @@ endmodule
 
 // Testbench-only stuff
 `ifndef SYNTHESIS
-`timescale 1ps/1ps
 module PeriodMonitor #(
-    parameter minperiodps = 1000,
-    parameter maxperiodps = 1000    // Set to 0 to ignore
+    parameter longint minperiodps = 1000,
+    parameter longint maxperiodps = 1000    // Set to 0 to ignore
 ) (
     input clock,
     input enable
 );
 
-    time edgetime = 1;
-    integer period;
+    time edgetime = 1ps;
+    time period;
 
     always @(posedge clock) begin
-        period = $time - edgetime;
-        edgetime = $time;
+        period = $time/1ps - edgetime;
+        edgetime = $time/1ps;
         if (period > 0) begin
             if (enable && (period < minperiodps)) begin
                 $display("PeriodMonitor detected a small period of %d ps at time %0t", period, $time);


### PR DESCRIPTION
The timescale directive isn't a local change so the propsed method avoids changing other bits of code which might rely on the default timescale.