### PR TITLE
Add sinkId parameter for integration

### DIFF
--- a/src/main/scala/Serdes.scala
+++ b/src/main/scala/Serdes.scala
@@ -532,7 +532,8 @@ class TLSerdesser(
     w: Int,
     clientParams: TLClientParameters,
     managerParams: TLManagerParameters,
-    beatBytes: Int = 8)
+    beatBytes: Int = 8,
+    endSinkId: Int = 0)
     (implicit p: Parameters) extends LazyModule {
 
   val clientNode = TLClientNode(
@@ -541,7 +542,8 @@ class TLSerdesser(
   val managerNode = TLManagerNode(
     Seq(TLManagerPortParameters(
       managers = Seq(managerParams),
-      beatBytes = beatBytes)))
+      beatBytes = beatBytes,
+      endSinkId = endSinkId)))
 
   lazy val module = new LazyModuleImp(this) {
     val io = IO(new Bundle {


### PR DESCRIPTION
Helps both top and testharness to respond to different parameter changes.
The default is the same value that is currently the default.