### PR TITLE
Update Switcher for rocket-chip Feb 14 2019

### DIFF
--- a/src/main/scala/Switcher.scala
+++ b/src/main/scala/Switcher.scala
@@ -103,10 +103,10 @@ class TLSwitcher(
 
   val device = new SimpleDevice("switcher", Seq("ucb-bar,switcher"))
 
-  val innode = TLManagerNode(Seq.fill(inPortN) {
+  val innode = TLManagerNode(Seq.tabulate(inPortN) { i =>
     TLManagerPortParameters(
       Seq(TLManagerParameters(
-        address    = address,
+        address    = Seq(address(i)),
         resources  = device.reg("mem"),
         regionType = if (cacheable) RegionType.UNCACHED
                      else RegionType.UNCACHEABLE,


### PR DESCRIPTION
Single mBus multi-port switcher support

rocket-chip now uses a single mBus with multiple nested ports for multiple memory channels so the canonical way of connecting the switcher would be with a `:*=` connection.
Without this change this will result in overlapping address spaces and fail in diplomacy.