### PR TITLE
Update switcher for large address spaces

### DIFF
--- a/src/main/scala/Switcher.scala
+++ b/src/main/scala/Switcher.scala
@@ -94,7 +94,7 @@ class TLSwitchArbiter(n: Int, edge: TLEdge) extends Module {
 class TLSwitcher(
     inPortN: Int,
     outPortN: Seq[Int],
-    address: Seq[AddressSet],
+    address: Seq[Seq[AddressSet]],
     cacheable: Boolean = true,
     executable: Boolean = true,
     beatBytes: Int = 4,
@@ -106,7 +106,7 @@ class TLSwitcher(
   val innode = TLManagerNode(Seq.tabulate(inPortN) { i =>
     TLManagerPortParameters(
       Seq(TLManagerParameters(
-        address    = Seq(address(i)),
+        address    = address(i),
         resources  = device.reg("mem"),
         regionType = if (cacheable) RegionType.UNCACHED
                      else RegionType.UNCACHEABLE,

--- a/src/main/scala/Unittests.scala
+++ b/src/main/scala/Unittests.scala
@@ -299,7 +299,7 @@ class SwitcherTest(implicit p: Parameters) extends LazyModule {
   val inChannels = 4
   val outChannels = 2
   val outIdBits = inIdBits + log2Ceil(inChannels)
-  val address = AddressSet(0x0, 0xffff)
+  val address = Seq(AddressSet(0x0, 0xffff))
 
   val fuzzers = Seq.fill(outChannels) {
     LazyModule(new TLFuzzer(
@@ -318,11 +318,11 @@ class SwitcherTest(implicit p: Parameters) extends LazyModule {
     beatBytes = beatBytes, lineBytes = lineBytes, idBits = outIdBits))
 
   val error = LazyModule(new TLError(
-    DevNullParams(Seq(address), beatBytes, lineBytes), beatBytes))
+    DevNullParams(address, beatBytes, lineBytes), beatBytes))
 
   val rams = Seq.fill(outChannels) {
     LazyModule(new TLTestRAM(
-      address = address,
+      address = address.head,
       beatBytes = beatBytes))
   }
 


### PR DESCRIPTION
This should have gone in with the project template bigint-mems bump for large address spaces.