### PR TITLE
update for debug apb & regiontype in rocket-chip

### DIFF
--- a/src/main/scala/NoDebug.scala
+++ b/src/main/scala/NoDebug.scala
@@ -16,8 +16,8 @@ trait HasNoDebugModuleImp {
   val clock: Clock
   val reset: Reset
 
-  debugIO.dmi.req.valid := false.B
-  debugIO.dmi.resp.ready := false.B
-  debugIO.dmiClock := clock
-  debugIO.dmiReset := reset.toBool
+  debugIO.get.dmi.req.valid := false.B
+  debugIO.get.dmi.resp.ready := false.B
+  debugIO.get.dmiClock := clock
+  debugIO.get.dmiReset := reset.toBool
 }

--- a/src/main/scala/Switcher.scala
+++ b/src/main/scala/Switcher.scala
@@ -109,7 +109,7 @@ class TLSwitcher(
         address    = address(i),
         resources  = device.reg("mem"),
         regionType = if (cacheable) RegionType.UNCACHED
-                     else RegionType.UNCACHEABLE,
+                     else RegionType.IDEMPOTENT,
         executable = executable,
         supportsGet        = TransferSizes(1, lineBytes),
         supportsPutPartial = TransferSizes(1, lineBytes),

--- a/src/main/scala/Switcher.scala
+++ b/src/main/scala/Switcher.scala
@@ -109,7 +109,7 @@ class TLSwitcher(
         address    = address(i),
         resources  = device.reg("mem"),
         regionType = if (cacheable) RegionType.UNCACHED
-                     else RegionType.IDEMPOTENT,
+                     else RegionType.VOLATILE,
         executable = executable,
         supportsGet        = TransferSizes(1, lineBytes),
         supportsPutPartial = TransferSizes(1, lineBytes),


### PR DESCRIPTION
https://github.com/freechipsproject/rocket-chip/commit/4c5b38edbcd6eb12a342982c1fcd99ece550037d made dmi optional, and https://github.com/chipsalliance/rocket-chip/pull/1940 split the region type.
Needed for recent rocket-chip versions but will break with older ones.