### PR TITLE
Fixes following removal of old chisel3 deprecations.

### DIFF
--- a/src/main/scala/Serdes.scala
+++ b/src/main/scala/Serdes.scala
@@ -107,7 +107,7 @@ class StreamWidener(inW: Int, outW: Int) extends Module {
   val inBeats = outW / inW
 
   val data = Reg(Vec(inBeats, UInt(inW.W)))
-  val keep = RegInit(Vec(Seq.fill(inBeats)(0.U(inBytes.W))))
+  val keep = RegInit(VecInit((Seq.fill(inBeats)(0.U(inBytes.W)))))
   val last = Reg(Bool())
 
   val idx = RegInit(0.U(log2Ceil(inBeats).W))

--- a/src/main/scala/Unittests.scala
+++ b/src/main/scala/Unittests.scala
@@ -69,7 +69,7 @@ class BlockDeviceTrackerTestDriver(nSectors: Int)(implicit p: Parameters)
     io.finished := state === s_done
 
     val beatBytes = dataBitsPerBeat / 8
-    val full_beat = Wire(UInt(8.W), init = Cat(read_sector, read_beat))
+    val full_beat = WireDefault(UInt(8.W), init = Cat(read_sector, read_beat))
     val expected_data = Fill(beatBytes, full_beat)
 
     assert(!tl.d.valid || tl.d.bits.data === expected_data,

--- a/src/main/scala/Util.scala
+++ b/src/main/scala/Util.scala
@@ -7,12 +7,14 @@ import freechips.rocketchip.diplomacy.{IdRange, ValName}
 import freechips.rocketchip.util.AsyncResetReg
 import freechips.rocketchip.tilelink._
 
-class ResetSync(c: Clock, lat: Int = 2) extends Module(_clock = c) {
+class ResetSync(c: Clock, lat: Int = 2) extends Module {
   val io = IO(new Bundle {
     val reset = Input(Bool())
     val reset_sync = Output(Bool())
   })
-  io.reset_sync := ShiftRegister(io.reset,lat)
+  withClock(c) {
+    io.reset_sync := ShiftRegister(io.reset,lat)
+  }
 }
 
 object ResetSync {
@@ -59,11 +61,19 @@ case class AsyncWideCounter(width: Int, inc: UInt = 1.U, reset: Boolean = true)
 
 // As WideCounter, but it's a module so it can take arbitrary clocks
 class WideCounterModule(w: Int, inc: UInt = 1.U, reset: Boolean = true, clockSignal: Clock = null, resetSignal: Bool = null)
-    extends Module(Option(clockSignal), Option(resetSignal)) {
+    extends Module {
   val io = IO(new Bundle {
     val value = Output(UInt(w.W))
   })
-  io.value := AsyncWideCounter(w, inc, reset).value
+  lazy val block = {
+    io.value := AsyncWideCounter(w, inc, reset).value
+  }
+  (clockSignal, resetSignal) match {
+    case (null, null) => block
+    case (null, r: Bool) => withReset(r) { block }
+    case (c: Clock, null) => withClock(c) { block }
+    case (c: Clock, r: Bool) => withClockAndReset(c, r) { block }
+  }
 }
 
 object WideCounterModule {
@@ -84,25 +94,28 @@ object WideCounterModule {
 class WordSync[T <: Data](gen: T, lat: Int = 2) extends Module {
   val size = gen.getWidth
   val io = IO(new Bundle {
-    val in = Flipped(gen.chiselCloneType)
-    val out = gen.chiselCloneType
+    val in = Flipped(chiselTypeOf(gen))
+    val out = chiselTypeOf(gen)
     val tx_clock = Input(Clock())
   })
   val bin2gray = Module(new BinToGray(gen,io.tx_clock))
   bin2gray.io.bin := io.in
   val out_gray = ShiftRegister(bin2gray.io.gray, lat)
-  io.out := gen.cloneType.fromBits(
+  io.out := (
     (0 until size)
-      .map(out_gray.asUInt >> _.U)
-      .reduceLeft((a: UInt, b: UInt) => a^b))
+      .map{ case og => (out_gray.asUInt >> og.U).asUInt }
+      .reduceLeft((a: UInt, b: UInt) => (a^b).asUInt)
+    )
 }
 
-class BinToGray[T <: Data](gen: T, c: Clock) extends Module(_clock = c) {
+class BinToGray[T <: Data](gen: T, c: Clock) extends Module {
   val io = IO(new Bundle {
-    val bin = Flipped(gen.chiselCloneType)
+    val bin = Flipped(chiselTypeOf(gen))
     val gray = UInt(gen.getWidth.W)
   })
-  io.gray := Reg(next=(io.bin.asUInt ^ (io.bin.asUInt >> 1.U)))
+  withClock(c) {
+    io.gray := RegNext(io.bin.asUInt ^ (io.bin.asUInt >> 1.U).asUInt())
+  }
 }
 
 object WordSync {


### PR DESCRIPTION
Replace Vecf(init) with VecInit()
Replace Wire(init) with WireDefault()
Replace Module(clock, reset) with withClockAndReset
Replace chiselCloneType with chiselTypeOf
Add asUInt to expressions that now return Bits

Don't merge this commit until we verify that the chisel3 changes are desirable.