### PR TITLE
Refactor traits as CanHave traits

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -14,9 +14,12 @@ class TestChipUnitTestConfig extends Config(
   new WithTestChipUnitTests ++ new BaseConfig)
 
 class WithBlockDevice extends Config((site, here, up) => {
-  case BlockDeviceKey => BlockDeviceConfig()
+  case BlockDeviceKey => Some(BlockDeviceConfig())
 })
 
 class WithNBlockDeviceTrackers(n: Int) extends Config((site, here, up) => {
-  case BlockDeviceKey => up(BlockDeviceKey, site).copy(nTrackers = n)
+  case BlockDeviceKey => up(BlockDeviceKey, site) match {
+    case Some(a) => Some(a.copy(nTrackers = n))
+    case None => None
+  }
 })

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -1,9 +1,11 @@
 package testchipip
 
 import chisel3._
+import chisel3.core.Reset
 import chisel3.util._
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.subsystem.{BaseSubsystem}
+import freechips.rocketchip.devices.debug.HasPeripheryDebug
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.util._
 import scala.math.min
@@ -181,26 +183,49 @@ class SimSerial(w: Int) extends BlackBox with HasBlackBoxResource {
   setResource("/testchipip/csrc/SimSerial.cc")
 }
 
-trait HasPeripherySerial { this: BaseSubsystem =>
+case object SerialKey extends Field[Boolean](false)
+
+trait CanHavePeripherySerial extends HasPeripheryDebug { this: BaseSubsystem =>
   private val portName = "serial-adapter"
-  val adapter = LazyModule(new SerialAdapter)
-  fbus.fromPort(Some(portName))() := adapter.node
+  val adapter = if (p(SerialKey)) {
+    val m = LazyModule(new SerialAdapter)
+    fbus.fromPort(Some(portName))() := m.node
+    Some(m)
+  } else {
+    None
+  }
 }
 
-trait HasPeripherySerialModuleImp extends LazyModuleImp {
-  implicit val p: Parameters
-  val outer: HasPeripherySerial
+trait CanHavePeripherySerialModuleImp extends LazyModuleImp {
+  val outer: CanHavePeripherySerial
+  val clock: Clock
+  val reset: Reset
 
-  val serial = IO(new SerialIO(SERIAL_IF_WIDTH))
-  val adapter = outer.adapter.module
-  serial.out <> Queue(adapter.io.serial.out)
-  adapter.io.serial.in <> Queue(serial.in)
+  val serial = if (p(SerialKey)) {
+    val serial_io = IO(new SerialIO(SERIAL_IF_WIDTH))
+
+    val adapter = outer.adapter.get.module
+    serial_io.out <> Queue(adapter.io.serial.out)
+    adapter.io.serial.in <> Queue(serial_io.in)
+
+    outer.debugOpt.map { debug =>
+      val debugIO = debug.module.io.dmi
+      debugIO.get.dmi.req.valid := false.B
+      debugIO.get.dmi.resp.ready := false.B
+      debugIO.get.dmiClock := clock
+      debugIO.get.dmiReset := reset.toBool
+    }
+    Some(serial_io)
+  } else {
+    None
+  }
 
   def connectSimSerial() = {
     val sim = Module(new SimSerial(SERIAL_IF_WIDTH))
     sim.io.clock := clock
     sim.io.reset := reset
-    sim.io.serial <> serial
+    sim.io.serial <> serial.get
     sim.io.exit
   }
 }
+

--- a/src/main/scala/UARTAdapter.scala
+++ b/src/main/scala/UARTAdapter.scala
@@ -148,12 +148,12 @@ class SimUART(uartno: Int) extends BlackBox(Map("UARTNO" -> IntParam(uartno))) w
 // to the outer system to interact with the DUT UART.
 //************************************************************************************
 
-trait CanHavePeripheryUARTWithAdapter extends HasPeripheryUART { this: BaseSubsystem =>
+trait CanHavePeripheryUARTAdapter extends HasPeripheryUART { this: BaseSubsystem =>
 }
 
-trait CanHavePeripheryUARTWithAdapterImp extends HasPeripheryUARTModuleImp {
+trait CanHavePeripheryUARTAdapterModuleImp extends HasPeripheryUARTModuleImp {
   implicit val p: Parameters
-  val outer: CanHavePeripheryUARTWithAdapter
+  val outer: CanHavePeripheryUARTAdapter
 
   /**
    * Connect the DUT UARTs to a UARTAdapter in the outer system.

--- a/src/main/scala/Unittests.scala
+++ b/src/main/scala/Unittests.scala
@@ -113,7 +113,7 @@ class BlockDeviceTrackerTest(implicit p: Parameters) extends LazyModule
 
 class BlockDeviceTrackerTestWrapper(implicit p: Parameters) extends UnitTest {
   val testParams = p.alterPartial({
-    case BlockDeviceKey => BlockDeviceConfig()
+    case BlockDeviceKey => Some(BlockDeviceConfig())
   })
   val test = Module(LazyModule(
     new BlockDeviceTrackerTest()(testParams)).module)


### PR DESCRIPTION
Partnered to https://github.com/ucb-bar/chipyard/pull/347

- The new `CanHave` traits result in no-ops when `SerialKey` and `BlockDeviceKey` are set to a null value. (`SerialKey = false`, `BlockDeviceKey = None`)
- Users of these traits can mix this in to their default Top, and configure their behavior with the keys. I argue this is more elegant than the existing scheme of configuring the tops by manually cherry-picking traits. 
