### PR TITLE
Add a UART Adapter

### DIFF
--- a/src/main/resources/testchipip/csrc/SimUART.cc
+++ b/src/main/resources/testchipip/csrc/SimUART.cc
@@ -6,7 +6,7 @@
 
 #include "uart.h"
 
-uart_t *uart = 0;
+uart_t *uart = NULL;
 
 extern "C" void uart_init(
         const char *filename,
@@ -27,7 +27,7 @@ extern "C" void uart_tick(
         unsigned char in_ready,
         char *in_bits)
 {
-    if (uart == 0) {
+    if (uart == NULL) {
         *out_ready = 0;
         *in_valid = 0;
         return;

--- a/src/main/resources/testchipip/csrc/SimUART.cc
+++ b/src/main/resources/testchipip/csrc/SimUART.cc
@@ -1,0 +1,39 @@
+#include <vpi_user.h>
+#include <svdpi.h>
+
+#include "uart.h"
+#include <stdio.h>
+
+uart_t *uart = 0;
+
+extern "C" void uart_init(
+        const char *filename,
+        int uartno)
+{
+    uart = new uart_t(filename, uartno);
+}
+
+extern "C" void uart_tick(
+        unsigned char out_valid,
+        unsigned char *out_ready,
+        char out_bits,
+
+        unsigned char *in_valid,
+        unsigned char in_ready,
+        char *in_bits)
+{
+    if (uart == 0) {
+        *out_ready = 0;
+        *in_valid = 0;
+        return;
+    }
+
+    uart->tick(
+        out_valid,
+        out_ready,
+        out_bits,
+
+        in_valid,
+        in_ready,
+        in_bits);
+}

--- a/src/main/resources/testchipip/csrc/SimUART.cc
+++ b/src/main/resources/testchipip/csrc/SimUART.cc
@@ -1,8 +1,10 @@
 #include <vpi_user.h>
 #include <svdpi.h>
 
-#include "uart.h"
 #include <stdio.h>
+#include <string.h>
+
+#include "uart.h"
 
 uart_t *uart = 0;
 
@@ -10,7 +12,10 @@ extern "C" void uart_init(
         const char *filename,
         int uartno)
 {
-    uart = new uart_t(filename, uartno);
+    if (strlen(filename) != 0)
+        uart = new uart_t(filename, uartno);
+    else
+        uart = new uart_t(0, uartno);
 }
 
 extern "C" void uart_tick(

--- a/src/main/resources/testchipip/csrc/uart.cc
+++ b/src/main/resources/testchipip/csrc/uart.cc
@@ -12,7 +12,7 @@
 #include <unistd.h>
 
 // name length limit for ptys
-#define SLAVENAMELEN 256
+#define PTYNAMELEN 256
 
 /* There is no "backpressure" to the user input for sigs. only one at a time
  * non-zero value represents unconsumed special char input.
@@ -58,11 +58,11 @@ uart_t::uart_t(const char* filename_prefix, int uartno)
         this->outputfd = STDOUT_FILENO;
     } else {
         // for UARTs that are not UART0, use a PTY
-        char slavename[SLAVENAMELEN];
+        char slavename[PTYNAMELEN];
         int ptyfd = posix_openpt(O_RDWR | O_NOCTTY);
         grantpt(ptyfd);
         unlockpt(ptyfd);
-        ptsname_r(ptyfd, slavename, SLAVENAMELEN);
+        ptsname_r(ptyfd, slavename, PTYNAMELEN);
 
         // create symlink for reliable location to find uart pty
         std::string symlinkname = std::string("uartpty") + std::to_string(uartno);

--- a/src/main/resources/testchipip/csrc/uart.cc
+++ b/src/main/resources/testchipip/csrc/uart.cc
@@ -1,0 +1,138 @@
+//See LICENSE for license details
+
+#include "uart.h"
+#include <sys/stat.h>
+#include <fcntl.h>
+
+#define _XOPEN_SOURCE
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifndef _WIN32
+#include <unistd.h>
+
+// name length limit for ptys
+#define SLAVENAMELEN 256
+
+/* There is no "backpressure" to the user input for sigs. only one at a time
+ * non-zero value represents unconsumed special char input.
+ *
+ * Reset to zero once consumed.
+ */
+
+// This is fine for multiple UARTs because UARTs > uart 0 will use pty, not stdio
+char specialchar = 0;
+
+void sighand(int s) {
+    switch (s) {
+        case SIGINT:
+            // ctrl-c
+            specialchar = 0x3;
+            break;
+        default:
+            specialchar = 0x0;
+    }
+}
+#endif
+
+uart_t::uart_t(const char* filename_prefix, int uartno)
+{
+    if (filename_prefix) {
+        printf("[UART_DEBUG] Setup UART%d with filename_prefix: %s\n", uartno, filename_prefix);
+    }
+
+    this->inputfd = 0;
+    this->outputfd = 0;
+    this->print_file = false;
+
+    if (uartno == 0) {
+        // signal handler so ctrl-c doesn't kill simulation when UART is attached
+        // to stdin/stdout
+        struct sigaction sigIntHandler;
+        sigIntHandler.sa_handler = sighand;
+        sigemptyset(&sigIntHandler.sa_mask);
+        sigIntHandler.sa_flags = 0;
+        sigaction(SIGINT, &sigIntHandler, NULL);
+        printf("[UART] UART0 is here (stdin/stdout).\n");
+        this->inputfd = STDIN_FILENO;
+        this->outputfd = STDOUT_FILENO;
+    } else {
+        // for UARTs that are not UART0, use a PTY
+        char slavename[SLAVENAMELEN];
+        int ptyfd = posix_openpt(O_RDWR | O_NOCTTY);
+        grantpt(ptyfd);
+        unlockpt(ptyfd);
+        ptsname_r(ptyfd, slavename, SLAVENAMELEN);
+
+        // create symlink for reliable location to find uart pty
+        std::string symlinkname = std::string("uartpty") + std::to_string(uartno);
+        // unlink in case symlink already exists
+        unlink(symlinkname.c_str());
+        if(symlink(slavename, symlinkname.c_str())) {
+            printf("[UART] Failed to created symlink with slave %s to symlink name %s\n", slavename, symlinkname.c_str());
+            exit(1);
+        }
+        printf("[UART] UART%d is on PTY: %s, symlinked at %s\n", uartno, slavename, symlinkname.c_str());
+        printf("[UART] Attach to this UART with 'sudo screen %s' or 'sudo screen %s'\n", slavename, symlinkname.c_str());
+        this->inputfd = ptyfd;
+        this->outputfd = ptyfd;
+    }
+
+    // if filename exists then put to file
+    if (filename_prefix) {
+        print_file = true;
+        std::string uartlogname = std::string(filename_prefix) + std::to_string(uartno);
+        printf("[UART] UART stdout being redirected to %s\n", uartlogname.c_str());
+        this->outputfd = open(uartlogname.c_str(), O_RDWR | O_CREAT, 0644);
+    }
+
+    // Don't block on reads if there is nothing typed in
+    fcntl(inputfd, F_SETFL, fcntl(inputfd, F_GETFL) | O_NONBLOCK);
+}
+
+uart_t::~uart_t() {
+    if (print_file)
+        close(this->outputfd);
+}
+
+void uart_t::tick(
+        unsigned char out_valid,
+        unsigned char *out_ready,
+        char out_bits,
+
+        unsigned char *in_valid,
+        unsigned char in_ready,
+        char *in_bits)
+{
+    *out_ready = true;
+    *in_valid = false;
+
+    if (in_ready) {
+        char inp;
+        int readamt;
+        if (specialchar) {
+            // send special character (e.g. ctrl-c)
+            // for stdin handling
+            //
+            // PTY should never trigger this
+            inp = specialchar;
+            specialchar = 0;
+            readamt = 1;
+        } else {
+            // else check if we have input
+            readamt = ::read(inputfd, &inp, 1);
+        }
+
+        if (readamt > 0) {
+            *in_bits = inp;
+            *in_valid = true;
+        }
+    }
+
+    if (*out_ready && out_valid) {
+        if (::write(outputfd, &out_bits, 1) == -1) {
+            printf("[UART] Failed to write to output fd\n");
+            exit(1);
+        }
+    }
+}

--- a/src/main/resources/testchipip/csrc/uart.cc
+++ b/src/main/resources/testchipip/csrc/uart.cc
@@ -39,10 +39,6 @@ void sighand(int s) {
 
 uart_t::uart_t(const char* filename_prefix, int uartno)
 {
-    if (filename_prefix) {
-        printf("[UART_DEBUG] Setup UART%d with filename_prefix: %s\n", uartno, filename_prefix);
-    }
-
     this->inputfd = 0;
     this->outputfd = 0;
     this->print_file = false;
@@ -55,7 +51,10 @@ uart_t::uart_t(const char* filename_prefix, int uartno)
         sigemptyset(&sigIntHandler.sa_mask);
         sigIntHandler.sa_flags = 0;
         sigaction(SIGINT, &sigIntHandler, NULL);
-        printf("[UART] UART0 is here (stdin/stdout).\n");
+        if (filename_prefix)
+            printf("[UART] UART0 is here (stdin).\n");
+        else
+            printf("[UART] UART0 is here (stdin/stdout).\n");
         this->inputfd = STDIN_FILENO;
         this->outputfd = STDOUT_FILENO;
     } else {
@@ -71,7 +70,7 @@ uart_t::uart_t(const char* filename_prefix, int uartno)
         // remove in case symlink already exists
         remove(symlinkname.c_str());
         if(symlink(ptyname, symlinkname.c_str())) {
-            printf("[UART_ERR] Failed to created symlink with slave %s to symlink name %s\n", ptyname, symlinkname.c_str());
+            printf("[UART_ERR] Failed to created symlink with ptyname %s to symlink name %s\n", ptyname, symlinkname.c_str());
             exit(1);
         }
         printf("[UART] UART%d is on PTY: %s, symlinked at %s\n", uartno, ptyname, symlinkname.c_str());
@@ -84,7 +83,7 @@ uart_t::uart_t(const char* filename_prefix, int uartno)
     if (filename_prefix) {
         print_file = true;
         std::string uartlogname = std::string(filename_prefix) + std::to_string(uartno);
-        printf("[UART] UART stdout being redirected to file: %s\n", uartlogname.c_str());
+        printf("[UART] UART%d stdout being redirected to file: %s\n", uartno, uartlogname.c_str());
         this->outputfd = open(uartlogname.c_str(), O_RDWR | O_CREAT, 0644);
     }
 

--- a/src/main/resources/testchipip/csrc/uart.cc
+++ b/src/main/resources/testchipip/csrc/uart.cc
@@ -69,7 +69,7 @@ uart_t::uart_t(const char* filename_prefix, int uartno)
         // unlink in case symlink already exists
         unlink(symlinkname.c_str());
         if(symlink(slavename, symlinkname.c_str())) {
-            printf("[UART] Failed to created symlink with slave %s to symlink name %s\n", slavename, symlinkname.c_str());
+            printf("[UART_ERR] Failed to created symlink with slave %s to symlink name %s\n", slavename, symlinkname.c_str());
             exit(1);
         }
         printf("[UART] UART%d is on PTY: %s, symlinked at %s\n", uartno, slavename, symlinkname.c_str());
@@ -82,7 +82,7 @@ uart_t::uart_t(const char* filename_prefix, int uartno)
     if (filename_prefix) {
         print_file = true;
         std::string uartlogname = std::string(filename_prefix) + std::to_string(uartno);
-        printf("[UART] UART stdout being redirected to %s\n", uartlogname.c_str());
+        printf("[UART] UART stdout being redirected to file: %s\n", uartlogname.c_str());
         this->outputfd = open(uartlogname.c_str(), O_RDWR | O_CREAT, 0644);
     }
 
@@ -131,7 +131,7 @@ void uart_t::tick(
 
     if (*out_ready && out_valid) {
         if (::write(outputfd, &out_bits, 1) == -1) {
-            printf("[UART] Failed to write to output fd\n");
+            printf("[UART_ERR] Failed to write to outputfd %d\n", outputfd);
             exit(1);
         }
     }

--- a/src/main/resources/testchipip/csrc/uart.h
+++ b/src/main/resources/testchipip/csrc/uart.h
@@ -1,0 +1,30 @@
+#ifndef __SIMUART_H
+#define __SIMUART_H
+
+#include <signal.h>
+#include <string.h>
+#include <string>
+
+class uart_t
+{
+    public:
+        uart_t(
+            const char* filename_prefix,
+            int uartno);
+        ~uart_t();
+        void tick(
+            unsigned char out_valid,
+            unsigned char *out_ready,
+            char out_bits,
+
+            unsigned char *in_valid,
+            unsigned char in_ready,
+            char *in_bits);
+
+    private:
+        bool print_file;
+        int inputfd;
+        int outputfd;
+};
+
+#endif // __SIMUART_H

--- a/src/main/resources/testchipip/vsrc/SimUART.v
+++ b/src/main/resources/testchipip/vsrc/SimUART.v
@@ -1,0 +1,77 @@
+`define DATA_WIDTH 8
+
+import "DPI-C" function void uart_init(
+    input  string  filename,
+    input  int     uartno
+);
+
+import "DPI-C" function void uart_tick
+(
+    input  bit     serial_out_valid,
+    output bit     serial_out_ready,
+    input  byte    serial_out_bits,
+
+    output bit     serial_in_valid,
+    input  bit     serial_in_ready,
+    output byte    serial_in_bits
+);
+
+module SimUART #(UARTNO) (
+    input              clock,
+    input              reset,
+
+    input                    serial_out_valid,
+    output                   serial_out_ready,
+    input  [`DATA_WIDTH-1:0] serial_out_bits,
+
+    output                   serial_in_valid,
+    input                    serial_in_ready,
+    output [`DATA_WIDTH-1:0] serial_in_bits
+);
+
+    bit __in_valid;
+    bit __out_ready;
+    byte __in_bits;
+    string __uartlog;
+    int __uartno;
+
+    initial begin
+        $value$plusargs("uartlog=%s", __uartlog);
+        uart_init(__uartlog, __uartno);
+    end
+
+    reg __in_valid_reg;
+    reg __out_ready_reg;
+    reg [`DATA_WIDTH-1:0] __in_bits_reg;
+
+    assign serial_in_valid  = __in_valid_reg;
+    assign serial_in_bits   = __in_bits_reg;
+    assign serial_out_ready = __out_ready_reg;
+
+    // Evaluate the signals on the positive edge
+    always @(posedge clock) begin
+        if (reset) begin
+            __in_valid = 0;
+            __out_ready = 0;
+
+            __in_valid_reg <= 0;
+            __in_bits_reg <= 0;
+            __out_ready_reg <= 0;
+            __uartno = UARTNO;
+        end else begin
+            uart_tick(
+                serial_out_valid,
+                __out_ready,
+                serial_out_bits,
+                __in_valid,
+                serial_in_ready,
+                __in_bits
+            );
+
+            __out_ready_reg <= __out_ready;
+            __in_valid_reg  <= __in_valid;
+            __in_bits_reg   <= __in_bits;
+        end
+    end
+
+endmodule

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -47,7 +47,7 @@ class SerialAdapterModule(outer: SerialAdapter) extends LazyModuleImp(outer) {
 
   val (cmd_read :: cmd_write :: Nil) = Enum(2)
   val (s_cmd :: s_addr :: s_len ::
-       s_read_req  :: s_read_data :: s_read_body :: 
+       s_read_req  :: s_read_data :: s_read_body ::
        s_write_body :: s_write_data :: s_write_ack :: Nil) = Enum(9)
   val state = RegInit(s_cmd)
 

--- a/src/main/scala/UARTAdapter.scala
+++ b/src/main/scala/UARTAdapter.scala
@@ -1,4 +1,4 @@
-package testchipip
+package sifive.blocks.devices.uart
 
 import chisel3._
 import chisel3.util._
@@ -11,6 +11,7 @@ import freechips.rocketchip.subsystem.{BaseSubsystem}
 import freechips.rocketchip.config.{Field}
 
 import sifive.blocks.devices.uart._
+import testchipip.{SerialIO}
 
 object UARTAdapterConsts {
   val DATA_WIDTH = 8
@@ -112,7 +113,7 @@ class UARTAdapter(uartno: Int)(implicit p: Parameters) extends Module
   val sim = Module(new SimUART(uartno))
 
   sim.io.clock := clock
-  sim.io.reset := reset
+  sim.io.reset := reset.asBool
 
   sim.io.serial.out.bits := txfifo.io.deq.bits
   sim.io.serial.out.valid := txfifo.io.deq.valid

--- a/src/main/scala/UARTAdapter.scala
+++ b/src/main/scala/UARTAdapter.scala
@@ -1,0 +1,153 @@
+package testchipip
+
+import chisel3._
+import chisel3.util._
+import chisel3.core.{IntParam, StringParam}
+
+import freechips.rocketchip.config.{Parameters}
+import freechips.rocketchip.subsystem.{PeripheryBusKey}
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.subsystem.{BaseSubsystem}
+import freechips.rocketchip.config.{Field}
+
+import sifive.blocks.devices.uart._
+
+object UARTAdapterConsts {
+  val DATA_WIDTH = 8
+}
+import UARTAdapterConsts._
+
+case object UARTAdapterKey extends Field[Seq[UARTAdapterParams]](Nil)
+
+case class UARTAdapterParams(
+  baudRateInit: BigInt = BigInt(115200)
+)
+
+class UARTAdapter(uartno: Int)(implicit p: Parameters) extends Module
+{
+  val io = IO(new Bundle {
+    val uart = Flipped(new UARTPortIO)
+  })
+
+  val frequency = p(PeripheryBusKey).frequency
+  val baudrate = p(UARTAdapterKey)(uartno).baudRateInit
+  val div = (p(PeripheryBusKey).frequency / baudrate).toInt
+
+  val txfifo = Module(new Queue(UInt(DATA_WIDTH.W), 128))
+  val rxfifo = Module(new Queue(UInt(DATA_WIDTH.W), 128))
+
+  val uart_io = io.uart
+
+  val sTxIdle :: sTxWait :: sTxData :: sTxBreak :: Nil = Enum(4)
+  val txState = RegInit(sTxIdle)
+  val txData = Reg(UInt(DATA_WIDTH.W))
+  // iterate through bits in byte to deserialize
+  val (txDataIdx, txDataWrap) = Counter(txState === sTxData, DATA_WIDTH)
+  // iterate using div to convert clock rate to baud
+  val (txBaudCount, txBaudWrap) = Counter(txState === sTxWait, div)
+  val (txSlackCount, txSlackWrap) = Counter(txState === sTxIdle && uart_io.txd === 0.U, 4)
+
+  switch(txState) {
+    is(sTxIdle) {
+      when(txSlackWrap) {
+        txData  := 0.U
+        txState := sTxWait
+      }
+    }
+    is(sTxWait) {
+      when(txBaudWrap) {
+        txState := sTxData
+      }
+    }
+    is(sTxData) {
+      txData := txData | (uart_io.txd << txDataIdx)
+      when(txDataWrap) {
+        txState := Mux(uart_io.txd === 1.U, sTxIdle, sTxBreak)
+      }.otherwise {
+        txState := sTxWait
+      }
+    }
+    is(sTxBreak) {
+      when(uart_io.txd === 1.U) {
+        txState := sTxIdle
+      }
+    }
+  }
+
+  txfifo.io.enq.bits  := txData
+  txfifo.io.enq.valid := txDataWrap
+
+  val sRxIdle :: sRxStart :: sRxData :: Nil = Enum(3)
+  val rxState = RegInit(sRxIdle)
+  // iterate using div to convert clock rate to baud
+  val (rxBaudCount, rxBaudWrap) = Counter(true.B, div)
+  // iterate through bits in byte to deserialize
+  val (rxDataIdx, rxDataWrap) = Counter(rxState === sRxData && rxBaudWrap, DATA_WIDTH)
+
+  uart_io.rxd := 1.U
+  switch(rxState) {
+    is(sRxIdle) {
+      uart_io.rxd := 1.U
+      when (rxBaudWrap && rxfifo.io.deq.valid) {
+        rxState := sRxStart
+      }
+    }
+    is(sRxStart) {
+      uart_io.rxd := 0.U
+      when(rxBaudWrap) {
+        rxState := sRxData
+      }
+    }
+    is(sRxData) {
+      uart_io.rxd := (rxfifo.io.deq.bits >> rxDataIdx)(0)
+      when(rxDataWrap && rxBaudWrap) {
+        rxState := sRxIdle
+      }
+    }
+  }
+  rxfifo.io.deq.ready := (rxState === sRxData) && rxDataWrap && rxBaudWrap
+
+  val sim = Module(new SimUART(uartno))
+
+  sim.io.clock := clock
+  sim.io.reset := reset
+
+  sim.io.serial.out.bits := txfifo.io.deq.bits
+  sim.io.serial.out.valid := txfifo.io.deq.valid
+  txfifo.io.deq.ready := sim.io.serial.out.ready
+
+  rxfifo.io.enq.bits := sim.io.serial.in.bits
+  rxfifo.io.enq.valid := sim.io.serial.in.valid
+  sim.io.serial.in.ready := rxfifo.io.enq.ready
+}
+
+class SimUART(uartno: Int) extends BlackBox(Map("UARTNO" -> IntParam(uartno))) with HasBlackBoxResource {
+  val io = IO(new Bundle {
+    val clock = Input(Clock())
+    val reset = Input(Bool())
+
+    val serial = Flipped(new SerialIO(DATA_WIDTH))
+  })
+
+  addResource("/testchipip/vsrc/SimUART.v")
+  addResource("/testchipip/csrc/SimUART.cc")
+  addResource("/testchipip/csrc/uart.cc")
+  addResource("/testchipip/csrc/uart.h")
+}
+
+trait CanHavePeripheryUARTWithAdapter extends HasPeripheryUART { this: BaseSubsystem =>
+}
+
+trait CanHavePeripheryUARTWithAdapterImp extends HasPeripheryUARTModuleImp {
+  implicit val p: Parameters
+  val outer: CanHavePeripheryUARTWithAdapter
+
+  def connectSimUARTs() = {
+    require(p(PeripheryUARTKey).size == p(UARTAdapterKey).size)
+    uart.zipWithIndex.foreach{ case (dut_io, i) =>
+      val uart_sim = Module(new UARTAdapter(i)(p))
+      uart_sim.io.uart.txd := dut_io.txd
+      dut_io.rxd := uart_sim.io.uart.rxd
+    }
+  }
+}


### PR DESCRIPTION
Adds a new trait that can be used in projects to create a UART and a corresponding UARTAdapter on the TestHarness side. By adding the plusarg `uartlog` you can create an output file(s) that gets the redirected `stdout`. I haven't tested in the `stdin` feature of this adapter but that was out of scope for this.

Todo: 
- [x] Have the output go to a file instead of `stdout`