### PR TITLE
Modularize connect methods

### DIFF
--- a/src/main/scala/BlockDevice.scala
+++ b/src/main/scala/BlockDevice.scala
@@ -458,15 +458,26 @@ trait CanHavePeripheryBlockDeviceModuleImp extends LazyModuleImp {
     io
   }
 
-  def connectSimBlockDevice(clock: Clock, reset: Bool) {
-    val sim = Module(new SimBlockDevice)
-    sim.io.clock := clock
-    sim.io.reset := reset
-    sim.io.bdev <> bdev.get
-  }
+  def connectSimBlockDevice(clock: Clock, reset: Bool) = SimBlockDevice.connect(clock, reset, bdev)
+  def connectBlockDeviceModel() = BlockDeviceModel.connect(bdev)
+}
 
-  def connectBlockDeviceModel() {
-    val model = Module(new BlockDeviceModel(16))
-    model.io <> bdev.get
+object SimBlockDevice {
+  def connect(clock: Clock, reset: Bool, bdev: Option[BlockDeviceIO])(implicit p: Parameters) {
+    bdev.foreach { b =>
+      val sim = Module(new SimBlockDevice)
+      sim.io.clock := clock
+      sim.io.reset := reset
+      sim.io.bdev <> b
+    }
+  }
+}
+
+object BlockDeviceModel {
+  def connect(bdev: Option[BlockDeviceIO])(implicit p: Parameters) {
+    bdev.foreach { b =>
+      val model = Module(new BlockDeviceModel(16))
+      model.io <> b
+    }
   }
 }

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -12,20 +12,18 @@ import scala.math.min
 case object SerialAdapter {
   val SERIAL_IF_WIDTH = 32
 
-  def connectSimSerial(serial: Option[SerialIO], clock: Clock, reset: Reset) = {
+  def connectSimSerial(serial: SerialIO, clock: Clock, reset: Reset) = {
     val sim = Module(new SimSerial(SERIAL_IF_WIDTH))
     sim.io.clock := clock
     sim.io.reset := reset
-    sim.io.serial <> serial.get
+    sim.io.serial <> serial
     sim.io.exit
   }
 
-  def tieoff(serial: Option[SerialIO]) {
-    serial.map { s =>
-      s.in.valid := false.B
-      s.in.bits := DontCare
-      s.out.ready := true.B
-    }
+  def tieoff(serial: SerialIO) {
+    serial.in.valid := false.B
+    serial.in.bits := DontCare
+    serial.out.ready := true.B
   }
 }
 import SerialAdapter._
@@ -228,9 +226,9 @@ trait CanHavePeripherySerialModuleImp extends LazyModuleImp {
     None
   }
 
-  def connectSimSerial() = SerialAdapter.connectSimSerial(serial, clock, reset)
+  def connectSimSerial() = serial.map { s => SerialAdapter.connectSimSerial(s, clock, reset) }.getOrElse(false.B)
 
-  def tieoffSerial() = SerialAdapter.tieoff(serial)
+  def tieoffSerial() = serial.foreach { s => SerialAdapter.tieoff(s) }
 
 }
 

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -1,7 +1,6 @@
 package testchipip
 
 import chisel3._
-import chisel3.core.Reset
 import chisel3.util._
 import freechips.rocketchip.config.{Parameters, Field}
 import freechips.rocketchip.subsystem.{BaseSubsystem}
@@ -12,6 +11,22 @@ import scala.math.min
 
 case object SerialAdapter {
   val SERIAL_IF_WIDTH = 32
+
+  def connectSimSerial(serial: Option[SerialIO], clock: Clock, reset: Reset) = {
+    val sim = Module(new SimSerial(SERIAL_IF_WIDTH))
+    sim.io.clock := clock
+    sim.io.reset := reset
+    sim.io.serial <> serial.get
+    sim.io.exit
+  }
+
+  def tieoff(serial: Option[SerialIO]) {
+    serial.map { s =>
+      s.in.valid := false.B
+      s.in.bits := DontCare
+      s.out.ready := true.B
+    }
+  }
 }
 import SerialAdapter._
 
@@ -179,8 +194,8 @@ class SimSerial(w: Int) extends BlackBox with HasBlackBoxResource {
     val exit = Output(Bool())
   })
 
-  setResource("/testchipip/vsrc/SimSerial.v")
-  setResource("/testchipip/csrc/SimSerial.cc")
+  addResource("/testchipip/vsrc/SimSerial.v")
+  addResource("/testchipip/csrc/SimSerial.cc")
 }
 
 case object SerialKey extends Field[Boolean](false)
@@ -213,20 +228,9 @@ trait CanHavePeripherySerialModuleImp extends LazyModuleImp {
     None
   }
 
-  def connectSimSerial() = {
-    val sim = Module(new SimSerial(SERIAL_IF_WIDTH))
-    sim.io.clock := clock
-    sim.io.reset := reset
-    sim.io.serial <> serial.get
-    sim.io.exit
-  }
+  def connectSimSerial() = SerialAdapter.connectSimSerial(serial, clock, reset)
 
-  def tieoffSerial() = {
-    serial.map { s =>
-      s.in.valid := false.B
-      s.in.bits := DontCare
-      s.out.ready := true.B
-    }
-  }
+  def tieoffSerial() = SerialAdapter.tieoff(serial)
+
 }
 

--- a/src/main/scala/UARTAdapter.scala
+++ b/src/main/scala/UARTAdapter.scala
@@ -132,6 +132,7 @@ object UARTAdapter {
   def connect(uart: Seq[UARTPortIO], div: Int) {
     uart.zipWithIndex.foreach { case (dut_io, i) =>
       val uart_sim = Module(new UARTAdapter(i, div))
+      uart_sim.suggestName("uart_sim_${i}")
       uart_sim.io.uart.txd := dut_io.txd
       dut_io.rxd := uart_sim.io.uart.rxd
     }


### PR DESCRIPTION
This takes the connect methods from SerialAdapter, BlockDevice, and UARTAdapter and puts them into objects so that they can be easily reused by Top and ChipTop (See ucb-bar/chipyard#480)