### PR TITLE
Delete Generator/TestHarness and fix ClockUtilTests

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -18,8 +18,15 @@ class WithTestChipUnitTests extends Config((site, here, up) => {
     TestChipUnitTests(testParams)
 })
 
+class WithClockUtilTests extends Config((site, here, up) => {
+  case UnitTests => (testParams: Parameters) => ClockUtilTests()
+})
+
 class TestChipUnitTestConfig extends Config(
   new WithTestChipUnitTests ++ new BaseConfig)
+
+class ClockUtilTestConfig extends Config(
+  new WithClockUtilTests ++ new BaseConfig)
 
 class WithBlockDevice extends Config((site, here, up) => {
   case BlockDeviceKey => Some(BlockDeviceConfig())

--- a/src/main/scala/Generator.scala
+++ b/src/main/scala/Generator.scala
@@ -1,7 +1,0 @@
-package testchipip
-
-import freechips.rocketchip.config.Parameters
-import firrtl.options.{StageMain}
-import freechips.rocketchip.system.{RocketChipStage}
-
-object Generator extends StageMain(new RocketChipStage)

--- a/src/main/scala/TestHarness.scala
+++ b/src/main/scala/TestHarness.scala
@@ -1,6 +1,0 @@
-package testchipip
-
-import freechips.rocketchip.config.Parameters
-
-class TestHarness(implicit p: Parameters)
-  extends freechips.rocketchip.unittest.TestHarness

--- a/src/main/scala/Unittests.scala
+++ b/src/main/scala/Unittests.scala
@@ -498,6 +498,5 @@ object TestChipUnitTests {
       Module(new SwitchTestWrapper),
       Module(new StreamWidthAdapterTest),
       Module(new NetworkXbarTest),
-      Module(new TLRingNetworkTestWrapper)) ++
-    ClockUtilTests()
+      Module(new TLRingNetworkTestWrapper))
 }


### PR DESCRIPTION
This removes the unnecessary Generator/TestHarness, as we can use a separate generator/harness in chipyard for unit-testing all packages.

Also fixes the ClockUtilTests blackboxes so that it can work in VCS. Unfortunately, they won't work in verilator because it doesn't support the delay primitive. 