### PR TITLE
Use rocket-chip's ClockGate API to reduce reduncancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ BAR projects generally use these components with [rocket-chip](https://github.co
 
 ## Usage
 Testchipip can be used in your project in one of two ways:
-1) As an sbt subproject that depends on rocket-chip, as in [project-template](https://github.com/ucb-bar/project-template/)
+1) As an sbt subproject that depends on rocket-chip, as in [chipyard](https://github.com/ucb-bar/chipyard/)
 2) As a maven dependency (e.g. write 
 
 ```

--- a/src/main/resources/testchipip/vsrc/ClockUtil.v
+++ b/src/main/resources/testchipip/vsrc/ClockUtil.v
@@ -35,26 +35,6 @@ module ClockInverter (
 
 endmodule
 
-module ClockGater (
-    input enable,
-    input clockIn,
-    output clockGated
-);
-
-    // REPLACE ME WITH A CLOCK CELL IF DESIRED
-
-    reg qd;
-
-    assign clockGated = qd & clockIn;
-
-    always @(*) begin
-        if (!clockIn) begin
-            qd = enable;
-        end
-    end
-
-endmodule
-
 module ClockMux2 (
     input clocksIn_0,
     input clocksIn_1,

--- a/src/main/resources/testchipip/vsrc/ClockUtil.v
+++ b/src/main/resources/testchipip/vsrc/ClockUtil.v
@@ -8,7 +8,7 @@ module ClockFlop (
     // REPLACE ME WITH A CLOCK CELL IF DESIRED
 
     always @(posedge clockIn)
-        clockOut <= d;
+        clockOut = d; // This should be a blocking assignment to deterministically order clock edges
 
 endmodule
 

--- a/src/main/scala/ClockUtilTests.scala
+++ b/src/main/scala/ClockUtilTests.scala
@@ -5,7 +5,7 @@ import chisel3.util._
 import chisel3.experimental.{withClock, withClockAndReset}
 import chisel3.core.IntParam
 import freechips.rocketchip.unittest._
-import freechips.rocketchip.util.{ResetCatchAndSync}
+import freechips.rocketchip.util.{ResetCatchAndSync, EICG_wrapper}
 
 class ClockMutexMuxTest(timeout: Int = 200000) extends UnitTest(timeout) {
 
@@ -15,7 +15,7 @@ class ClockMutexMuxTest(timeout: Int = 200000) extends UnitTest(timeout) {
     val clocks = freqs.map(x => Module(new ClockGenerator(x)).io.clock)
     val monitors = freqs.map(x => Module(new PeriodMonitor(x, Some(x))))
 
-    val mux = ClockMutexMux(clocks)
+    val mux = ClockMutexMux(clocks, () => new EICG_wrapper)
     mux.io.resetAsync := this.reset
 
     monitors.foreach(_.io.clock := mux.io.clockOut)


### PR DESCRIPTION
This removes the redundant `ClockGater` blackbox in testchipip and replaces it with the `ClockGate` set of APIs from rocket-chip.