### PR TITLE
Dromajo + TraceIO Cleanup

### DIFF
--- a/src/main/scala/Dromajo.scala
+++ b/src/main/scala/Dromajo.scala
@@ -63,7 +63,7 @@ class SimDromajoBridge(insnWidths: TracedInstructionWidths, numInsns: Int) exten
   dromajo.io.hartid := 0.U
   dromajo.io.pc := Cat(traces.map(t => UIntToAugmentedUInt(t.iaddr).sextTo(DromajoConstants.xLen)).reverse)
   dromajo.io.inst := Cat(traces.map(t => t.insn.pad(DromajoConstants.instBits)).reverse)
-  dromajo.io.wdata := Cat(traces.map(t => UIntToAugmentedUInt(t.wdata).sextTo(DromajoConstants.xLen)).reverse)
+  dromajo.io.wdata := Cat(traces.map(t => UIntToAugmentedUInt(t.wdata.get).sextTo(DromajoConstants.xLen)).reverse)
   dromajo.io.mstatus := 0.U // dromajo doesn't use mstatus currently
   dromajo.io.check := ((1 << traces.size) - 1).U
 

--- a/src/main/scala/Dromajo.scala
+++ b/src/main/scala/Dromajo.scala
@@ -4,12 +4,43 @@ import chisel3._
 import chisel3.util._
 import chisel3.experimental.{IntParam, StringParam}
 import freechips.rocketchip.config.{Parameters}
-import freechips.rocketchip.util.{UIntToAugmentedUInt}
+import freechips.rocketchip.util.{UIntToAugmentedUInt, ElaborationArtefacts}
+import freechips.rocketchip.subsystem.{ExtMem}
+import freechips.rocketchip.devices.tilelink.{PLICKey, CLINTKey, BootROMParams, PLICConsts, CLINTConsts}
 
 object DromajoConstants {
   val xLen = 64
   val instBits = 32
   val maxHartIdBits = 32
+}
+
+/**
+ * Helper object/function to generate Dromajo header file
+ */
+object DromajoHelper {
+  def addArtefacts()(implicit p: Parameters): Unit = {
+    var dromajoParams: String = ""
+    dromajoParams += "#ifndef DROMAJO_PARAMS_H"
+    dromajoParams += "\n#define DROMAJO_PARAMS_H"
+    dromajoParams += "\n\n" + "#define DROMAJO_RESET_VECTOR " + "\"" + "0x" + f"${p(BootROMParams).hang}%X" + "\""
+    dromajoParams += "\n" + "#define DROMAJO_MMIO_START " + "\"" + "0x" + f"${p(BootROMParams).address + p(BootROMParams).size}%X" + "\""
+    p(ExtMem) map { eP =>
+      dromajoParams += "\n" + "#define DROMAJO_MMIO_END " + "\"" + "0x" + f"${eP.master.base}%X" + "\""
+      // dromajo memory is in MiB chunks
+      dromajoParams += "\n" + "#define DROMAJO_MEM_SIZE " + "\"" + "0x" + f"${eP.master.size >> 20}%X" + "\""
+    }
+    p(PLICKey) map { pP =>
+      dromajoParams += "\n" + "#define DROMAJO_PLIC_BASE " + "\"" + "0x" + f"${pP.baseAddress}%X" + "\""
+      dromajoParams += "\n" + "#define DROMAJO_PLIC_SIZE " + "\"" + "0x" + f"${PLICConsts.size(pP.maxHarts)}%X" + "\""
+    }
+    p(CLINTKey) map { cP =>
+      dromajoParams += "\n" + "#define DROMAJO_CLINT_BASE " + "\"" + "0x" + f"${cP.baseAddress}%X" + "\""
+      dromajoParams += "\n" + "#define DROMAJO_CLINT_SIZE " + "\"" + "0x" + f"${CLINTConsts.size}%X" + "\""
+    }
+    dromajoParams += "\n\n#endif"
+
+    ElaborationArtefacts.add("""dromajo_params.h""", dromajoParams)
+  }
 }
 
 /**

--- a/src/main/scala/TraceIO.scala
+++ b/src/main/scala/TraceIO.scala
@@ -128,10 +128,8 @@ class TraceOutputTop(val widths: Seq[TracedInstructionWidths], val vecSizes: Seq
 }
 
 object TraceOutputTop {
-  def apply(proto: Seq[Vec[TracedInstruction]], protoExt: Seq[Vec[ExtendedTracedInstruction]]): TraceOutputTop =
-    new TraceOutputTop(
-      proto.map(t => TracedInstructionWidths(t.head)) ++ protoExt.map(t => TracedInstructionWidths(t.head)),
-      proto.map(_.size) ++ protoExt.map(_.size))
+  def apply(proto: Seq[Vec[ExtendedTracedInstruction]]): TraceOutputTop =
+    new TraceOutputTop(proto.map(t => TracedInstructionWidths(t.head)), proto.map(_.size))
 }
 
 //*****************************************************************
@@ -181,7 +179,9 @@ trait CanHaveTraceIOModuleImp extends LazyModuleImp {
   val outer: CanHaveTraceIO with HasTiles
 
   val traceIO = p(TracePortKey) map ( traceParams => {
-    val tio = IO(Output(TraceOutputTop(outer.traceNexus.in.map(_._1), outer.extTraceNexus.in.map(_._1))))
+    val extTraceSeqVec = (outer.traceNexus.in.map(_._1)).map(ExtendedTracedInstruction.fromVec(_)) ++ outer.extTraceNexus.in.map(_._1)
+    val tio = IO(Output(TraceOutputTop(extTraceSeqVec)))
+
     val tileInsts = ((outer.traceNexus.in) .map { case (tileTrace, _) => DeclockedTracedInstruction.fromVec(tileTrace) } ++
       (outer.extTraceNexus.in) .map { case (tileTrace, _) => DeclockedTracedInstruction.fromExtVec(tileTrace) })
 

--- a/src/main/scala/TraceIO.scala
+++ b/src/main/scala/TraceIO.scala
@@ -22,10 +22,7 @@ case class TracedInstructionWidths(iaddr: Int, insn: Int, wdata: Option[Int], ca
 
 object TracedInstructionWidths {
   def apply(tI: ExtendedTracedInstruction): TracedInstructionWidths = {
-    val wdataWidth = tI.wdata match {
-      case Some(wd) => Some(wd.getWidth)
-      case None => None
-    }
+    val wdataWidth = tI.wdata.map { w => w.getWidth }
     TracedInstructionWidths(tI.iaddr.getWidth, tI.insn.getWidth, wdataWidth, tI.cause.getWidth, tI.tval.getWidth)
   }
 
@@ -33,10 +30,8 @@ object TracedInstructionWidths {
     TracedInstructionWidths(tI.iaddr.getWidth, tI.insn.getWidth, None, tI.cause.getWidth, tI.tval.getWidth)
 }
 
-class ExtendedTracedInstruction(extended: Boolean = true)(implicit p: Parameters) extends TracedInstruction {
+class ExtendedTracedInstruction(val extended: Boolean = true)(implicit p: Parameters) extends TracedInstruction {
   val wdata = if (extended) Some(UInt(xLen.W)) else None
-
-  override def cloneType: this.type = new ExtendedTracedInstruction(extended).asInstanceOf[this.type]
 }
 
 object ExtendedTracedInstruction {
@@ -72,10 +67,7 @@ class DeclockedTracedInstruction(val widths: TracedInstructionWidths) extends Bu
   val valid = Bool()
   val iaddr = UInt(widths.iaddr.W)
   val insn = UInt(widths.insn.W)
-  val wdata = widths.wdata match {
-    case Some(w) => Some(UInt(w.W))
-    case None => None
-  }
+  val wdata = widths.wdata.map { w => UInt(w.W) }
   val priv = UInt(3.W)
   val exception = Bool()
   val interrupt = Bool()


### PR DESCRIPTION
This moves the Dromajo header code into a helper object and cleans up the TraceIO code a bit so that there are no more 1.B wires.