### PR TITLE
Add constructor and parser for a dramsim ini directory from the cmd line

### DIFF
--- a/src/main/resources/testchipip/csrc/SimDRAM.cc
+++ b/src/main/resources/testchipip/csrc/SimDRAM.cc
@@ -15,6 +15,7 @@ extern "C" void *memory_init(
 {
     mm_t *mm;
     s_vpi_vlog_info info;
+    std::string ini_dir = "dramsim2_ini";
 
     if (dramsim < 0) {
         if (!vpi_get_vlog_info(&info))
@@ -24,11 +25,13 @@ extern "C" void *memory_init(
         for (int i = 1; i < info.argc; i++) {
             if (strcmp(info.argv[i], "+dramsim") == 0)
                 dramsim = 1;
+            if (std::string(info.argv[i]).find("+dramsim_ini_dir=") == 0)
+                ini_dir = info.argv[i] + strlen("+dramsim_ini_dir=");
         }
     }
 
     if (dramsim)
-        mm = (mm_t *) (new mm_dramsim2_t(1 << id_bits));
+        mm = (mm_t *) (new mm_dramsim2_t(ini_dir, 1 << id_bits));
     else
         mm = (mm_t *) (new mm_magic_t);
 

--- a/src/main/resources/testchipip/csrc/mm_dramsim2.h
+++ b/src/main/resources/testchipip/csrc/mm_dramsim2.h
@@ -39,6 +39,10 @@ class mm_dramsim2_t : public mm_t
   mm_dramsim2_t(int axi4_ids) : 
       read_id_busy(axi4_ids, false),
       write_id_busy(axi4_ids, false) {};
+  mm_dramsim2_t(std::string ini_dir, int axi4_ids) :
+      ini_dir(ini_dir),
+      read_id_busy(axi4_ids, false),
+      write_id_busy(axi4_ids, false) {};
   mm_dramsim2_t(std::string memory_ini, std::string system_ini, std::string ini_dir, int axi4_ids) :
       memory_ini(memory_ini),
       system_ini(system_ini),


### PR DESCRIPTION
This avoid the need to symlink the dramsim_ini directory everywhere.
This also maintains the default behavior if people still want to use that.