### PR TITLE
BlockDevice and SerialAdapter require minLatency > 0 (Fix Issue #88)

### DIFF
--- a/src/main/scala/BlockDevice.scala
+++ b/src/main/scala/BlockDevice.scala
@@ -119,6 +119,7 @@ class BlockDeviceTrackerModule(outer: BlockDeviceTracker)
   val req = Reg(new BlockDeviceFrontendRequest)
 
   require (tl.a.bits.data.getWidth == dataBitsPerBeat)
+  require (edge.manager.minLatency > 0)
 
   val (s_idle :: s_bdev_req :: s_bdev_read_data ::
        s_bdev_write_data :: s_bdev_write_resp ::

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -51,6 +51,8 @@ class SerialAdapterModule(outer: SerialAdapter) extends LazyModuleImp(outer) {
 
   val (mem, edge) = outer.node.out(0)
 
+  require (edge.manager.minLatency > 0)
+
   val pAddrBits = edge.bundle.addressBits
   val wordLen = 64
   val nChunksPerWord = wordLen / w


### PR DESCRIPTION
Let's put this in after the RC bump is concluded.