### PR TITLE
Handle RC#2521 in DromajoHelper

### DIFF
--- a/src/main/scala/Dromajo.scala
+++ b/src/main/scala/Dromajo.scala
@@ -5,8 +5,8 @@ import chisel3.util._
 import chisel3.experimental.{IntParam, StringParam}
 import freechips.rocketchip.config.{Parameters}
 import freechips.rocketchip.util.{UIntToAugmentedUInt, ElaborationArtefacts}
-import freechips.rocketchip.subsystem.{ExtMem}
-import freechips.rocketchip.devices.tilelink.{PLICKey, CLINTKey, BootROMParams, PLICConsts, CLINTConsts}
+import freechips.rocketchip.subsystem.{ExtMem, HierarchicalLocation}
+import freechips.rocketchip.devices.tilelink.{BootROMLocated, CLINTConsts, CLINTKey, PLICConsts, PLICKey}
 
 object DromajoConstants {
   val xLen = 64
@@ -18,12 +18,14 @@ object DromajoConstants {
  * Helper object/function to generate Dromajo header file
  */
 object DromajoHelper {
-  def addArtefacts()(implicit p: Parameters): Unit = {
+  def addArtefacts(location: HierarchicalLocation)(implicit p: Parameters): Unit = {
     var dromajoParams: String = ""
     dromajoParams += "#ifndef DROMAJO_PARAMS_H"
     dromajoParams += "\n#define DROMAJO_PARAMS_H"
-    dromajoParams += "\n\n" + "#define DROMAJO_RESET_VECTOR " + "\"" + "0x" + f"${p(BootROMParams).hang}%X" + "\""
-    dromajoParams += "\n" + "#define DROMAJO_MMIO_START " + "\"" + "0x" + f"${p(BootROMParams).address + p(BootROMParams).size}%X" + "\""
+    p(BootROMLocated(location)) map { brP =>
+      dromajoParams += "\n\n" + "#define DROMAJO_RESET_VECTOR " + "\"" + "0x" + f"${brP.hang}%X" + "\""
+      dromajoParams += "\n" + "#define DROMAJO_MMIO_START " + "\"" + "0x" + f"${brP.address + brP.size}%X" + "\""
+    }
     p(ExtMem) map { eP =>
       dromajoParams += "\n" + "#define DROMAJO_MMIO_END " + "\"" + "0x" + f"${eP.master.base}%X" + "\""
       // dromajo memory is in MiB chunks


### PR DESCRIPTION
https://github.com/chipsalliance/rocket-chip/pull/2521 replaces
   case object BootROMParams extends Field[BootROMParams]
with
   case class BootROMLocated(loc: HierarchicalLocation) extends Field[Option[BootROMParams]](None)

This commit updates DromajoHelper to take a HierarchicalLocation and updates the
lookup of DRAMOJO_RESET_VECTOR adn DRAMOJO_MMIO_START accordingly.

NOTE: you will want to bump RC at the same time that you bump to this ChipYard.  There will also be other changes needed in ChipYard.  