### PR TITLE
Serial writes directly to DRAM for fast program loading

### DIFF
--- a/src/main/resources/testchipip/csrc/SimSerial.cc
+++ b/src/main/resources/testchipip/csrc/SimSerial.cc
@@ -4,7 +4,9 @@
 #include <string>
 #include <fesvr/tsi.h>
 
-tsi_t *tsi = NULL;
+#include "serial.h"
+
+chipyard_tsi_t *tsi = NULL;
 
 extern "C" int serial_tick(
         unsigned char out_valid,
@@ -13,7 +15,10 @@ extern "C" int serial_tick(
 
         unsigned char *in_valid,
         unsigned char in_ready,
-        int *in_bits)
+        int *in_bits,
+        
+        int nchannels, long long mem_size,
+        int word_bytes, int line_bytes, int id_bits)
 {
     bool out_fire = *out_ready && out_valid;
     bool in_fire = *in_valid && in_ready;
@@ -24,7 +29,10 @@ extern "C" int serial_tick(
         if (!vpi_get_vlog_info(&info))
           abort();
 
-        tsi = new tsi_t(info.argc, info.argv);
+        tsi = new chipyard_tsi_t(
+                info.argc, info.argv,
+                nchannels, mem_size,
+                word_bytes, line_bytes, id_bits);
     }
 
     tsi->tick(out_valid, out_bits, in_ready);

--- a/src/main/resources/testchipip/csrc/mm.h
+++ b/src/main/resources/testchipip/csrc/mm.h
@@ -12,7 +12,7 @@ class mm_t
  public:
   mm_t() : data(0), size(0) {}
 
-  virtual void init(size_t sz, int word_size, int line_size);
+  virtual void init(size_t sz, int word_size, int line_size, int nchannels);
 
   virtual bool ar_ready() = 0;
   virtual bool aw_ready() = 0;
@@ -55,6 +55,7 @@ class mm_t
   virtual size_t get_size() { return size; }
   virtual size_t get_word_size() { return word_size; }
   virtual size_t get_line_size() { return line_size; }
+  virtual size_t get_nchannels() { return nchannels; }
 
   void write(uint64_t addr, uint8_t *data, uint64_t strb, uint64_t size);
   std::vector<char> read(uint64_t addr);
@@ -66,6 +67,7 @@ class mm_t
   size_t size;
   int word_size;
   int line_size;
+  int nchannels;
 };
 
 struct mm_rresp_t
@@ -93,7 +95,7 @@ class mm_magic_t : public mm_t
  public:
   mm_magic_t() : store_inflight(false) {}
 
-  virtual void init(size_t sz, int word_size, int line_size);
+  virtual void init(size_t sz, int word_size, int line_size, int nchannels);
 
   virtual bool ar_ready() { return true; }
   virtual bool aw_ready() { return !store_inflight; }

--- a/src/main/resources/testchipip/csrc/mm_dramsim2.cc
+++ b/src/main/resources/testchipip/csrc/mm_dramsim2.cc
@@ -41,10 +41,10 @@ void power_callback(double a, double b, double c, double d)
     //fprintf(stderr, "power callback: %0.3f, %0.3f, %0.3f, %0.3f\n",a,b,c,d);
 }
 
-void mm_dramsim2_t::init(size_t sz, int wsz, int lsz)
+void mm_dramsim2_t::init(size_t sz, int wsz, int lsz, int nch)
 {
   assert(lsz == 64); // assumed by dramsim2
-  mm_t::init(sz, wsz, lsz);
+  mm_t::init(sz, wsz, lsz, nch);
 
   dummy_data.resize(word_size);
 

--- a/src/main/resources/testchipip/csrc/mm_dramsim2.h
+++ b/src/main/resources/testchipip/csrc/mm_dramsim2.h
@@ -50,7 +50,7 @@ class mm_dramsim2_t : public mm_t
       read_id_busy(axi4_ids, false),
       write_id_busy(axi4_ids, false) {};
 
-  virtual void init(size_t sz, int word_size, int line_size);
+  virtual void init(size_t sz, int word_size, int line_size, int nchannels);
 
   virtual bool ar_ready();
   virtual bool aw_ready();

--- a/src/main/resources/testchipip/csrc/serial.cc
+++ b/src/main/resources/testchipip/csrc/serial.cc
@@ -1,0 +1,103 @@
+#include "serial.h"
+
+chipyard_tsi_t::chipyard_tsi_t(
+        int argc, char **argv,
+        int nchannels, unsigned long mem_size,
+        int word_bytes, int line_bytes, int id_bits)
+    : tsi_t(argc, argv)
+{
+    std::string ini_dir = "dramsim2_ini";
+    bool dramsim = false;
+
+    this->nchannels = nchannels;
+    this->line_bytes = line_bytes;
+    this->mems = (mm_t **) malloc(sizeof(mm_t *) * nchannels);
+    this->mem_size = mem_size;
+    this->loadprog = false;
+    this->fastload = false;
+
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "+dramsim") == 0)
+            dramsim = true;
+        if (std::string(argv[i]).find("+dramsim_ini_dir=") == 0)
+            ini_dir = argv[i] + strlen("+dramsim_ini_dir=");
+        if (strcmp(argv[i], "+fastload") == 0)
+            this->fastload = true;
+    }
+
+    if (dramsim) {
+        for (int i = 0; i < nchannels; i++)
+            this->mems[i] = (mm_t *) (new mm_dramsim2_t(ini_dir, 1 << id_bits));
+    } else {
+        for (int i = 0; i < nchannels; i++)
+            this->mems[i] = (mm_t *) (new mm_magic_t);
+    }
+
+    for (int i = 0; i < nchannels; i++)
+        this->mems[i]->init(mem_size, word_bytes, line_bytes, nchannels);
+}
+
+chipyard_tsi_t::~chipyard_tsi_t()
+{
+    for (int i = 0; i < nchannels; i++)
+        delete mems[i];
+    free(mems);
+}
+
+#define min(a, b) ((a < b) ? (a) : (b))
+
+void chipyard_tsi_t::write_chunk_fast(reg_t addr, size_t nbytes, char *src)
+{
+    while (nbytes > 0) {
+        reg_t lineno = addr / line_bytes;
+        char *mem = (char *) mems[lineno % nchannels]->get_data();
+        reg_t offset = addr % line_bytes;
+        reg_t to_copy = min(line_bytes - offset, nbytes);
+        char *dst = mem + (lineno / nchannels) * line_bytes + offset;
+
+        memcpy(dst, src, to_copy);
+
+        src += to_copy;
+        addr += to_copy;
+        nbytes -= to_copy;
+    }
+}
+
+void chipyard_tsi_t::read_chunk_fast(reg_t addr, size_t nbytes, char *dst)
+{
+    while (nbytes > 0) {
+        reg_t lineno = addr / line_bytes;
+        char *mem = (char *) mems[lineno % nchannels]->get_data();
+        reg_t offset = addr % line_bytes;
+        reg_t to_copy = min(line_bytes - offset, nbytes);
+        char *src = mem + (lineno / nchannels) * line_bytes + offset;
+
+        memcpy(dst, src, to_copy);
+
+        dst += to_copy;
+        addr += to_copy;
+        nbytes -= to_copy;
+    }
+}
+
+void chipyard_tsi_t::write_chunk(reg_t taddr, size_t nbytes, const void *src)
+{
+    char *chsrc = (char *) src;
+    reg_t addr = taddr % mem_size;
+
+    if (loadprog && nchannels > 0)
+        write_chunk_fast(addr, nbytes, chsrc);
+    else
+        tsi_t::write_chunk(taddr, nbytes, src);
+}
+
+void chipyard_tsi_t::read_chunk(reg_t taddr, size_t nbytes, void *dst)
+{
+    char *chdst = (char *) dst;
+    reg_t addr = taddr % mem_size;
+
+    if (loadprog && nchannels > 0)
+        read_chunk_fast(addr, nbytes, chdst);
+    else
+        tsi_t::read_chunk(taddr, nbytes, dst);
+}

--- a/src/main/resources/testchipip/csrc/serial.h
+++ b/src/main/resources/testchipip/csrc/serial.h
@@ -1,0 +1,39 @@
+#ifndef __TESTCHIPIP_SERIAL_H__
+#define __TESTCHIPIP_SERIAL_H__
+
+#include <fesvr/htif.h>
+#include <fesvr/tsi.h>
+#include "mm_dramsim2.h"
+
+class chipyard_tsi_t : public tsi_t
+{
+  public:
+    chipyard_tsi_t(int argc, char **argv,
+		   int nchannels, unsigned long mem_size,
+		   int word_bytes, int line_bytes, int id_bits);
+    ~chipyard_tsi_t();
+
+    void load_program() {
+        if (fastload)
+            printf("Using fastload to load program\n");
+        loadprog = fastload;
+        tsi_t::load_program();
+        loadprog = false;
+    }
+    void write_chunk(reg_t taddr, size_t nbytes, const void *src);
+    void read_chunk(reg_t taddr, size_t nbytes, void *dst);
+    mm_t *get_mem(int channel) { return mems[channel]; }
+
+  private:
+    mm_t **mems;
+    unsigned long mem_size;
+    int nchannels;
+    int line_bytes;
+    bool loadprog;
+    bool fastload;
+
+    void write_chunk_fast(reg_t addr, size_t nbytes, char *src);
+    void read_chunk_fast(reg_t addr, size_t nbytes, char *dst);
+};
+
+#endif

--- a/src/main/resources/testchipip/vsrc/SimDRAM.v
+++ b/src/main/resources/testchipip/vsrc/SimDRAM.v
@@ -1,14 +1,6 @@
-import "DPI-C" function chandle memory_init
-(
-  input longint mem_size,
-  input longint word_size,
-  input longint line_size,
-  input longint id_bits
-);
-
 import "DPI-C" function void memory_tick
 (
-  input  chandle channel,
+  input  int     channel,
 
   input  bit     reset,
 
@@ -46,11 +38,12 @@ import "DPI-C" function void memory_tick
 );
 
 module SimDRAM #(
-    parameter ADDR_BITS=32, DATA_BITS = 64, ID_BITS = 5,
+    parameter CHANNEL_ID = 0, NUM_CHANNELS = 1,
+              ADDR_BITS = 32, DATA_BITS = 64, ID_BITS = 5,
               MEM_SIZE = 1000 * 1000 * 1000,
               LINE_SIZE = 64,
               WORD_SIZE = DATA_BITS/8,
-              STRB_BITS=DATA_BITS/8)(
+              STRB_BITS = DATA_BITS/8)(
   input                  clock,
   input                  reset,
   output                 axi_aw_ready,
@@ -91,9 +84,6 @@ module SimDRAM #(
   output                 axi_r_bits_last,
   output [ID_BITS-1:0]   axi_r_bits_id
 );
-
-  reg initialized = 1'b0;
-  chandle channel;
 
   wire __ar_valid;
   wire [31:0] __ar_addr;
@@ -153,13 +143,8 @@ module SimDRAM #(
       __r_valid_reg  <= 1'b0;
       __b_valid_reg  <= 1'b0;
     end else begin
-      if (!initialized) begin
-        channel = memory_init(MEM_SIZE, WORD_SIZE, LINE_SIZE, ID_BITS);
-        initialized = 1'b1;
-      end
-
       memory_tick(
-        channel,
+        CHANNEL_ID,
 
         reset,
 

--- a/src/main/resources/testchipip/vsrc/SimSerial.v
+++ b/src/main/resources/testchipip/vsrc/SimSerial.v
@@ -6,21 +6,34 @@ import "DPI-C" function int serial_tick
 
     output bit     serial_in_valid,
     input  bit     serial_in_ready,
-    output int     serial_in_bits
+    output int     serial_in_bits,
+
+    input int      nchannels,
+    input longint  mem_size,
+    input int      word_bytes,
+    input int      line_bytes,
+    input int      id_bits
 );
 
-module SimSerial (
-    input         clock,
-    input         reset,
-    input         serial_out_valid,
-    output        serial_out_ready,
-    input  [31:0] serial_out_bits,
+module SimSerial #(
+    parameter SERIAL_WIDTH = 32,
+              NUM_CHANNELS = 1,
+              MEM_SIZE = 1000 * 1000 * 1000,
+              WORD_BYTES = 8,
+              LINE_BYTES = 64,
+              ID_BITS = 5)
+(
+    input                     clock,
+    input                     reset,
+    input                     serial_out_valid,
+    output                    serial_out_ready,
+    input  [SERIAL_WIDTH-1:0] serial_out_bits,
 
-    output        serial_in_valid,
-    input         serial_in_ready,
-    output [31:0] serial_in_bits,
+    output                    serial_in_valid,
+    input                     serial_in_ready,
+    output [SERIAL_WIDTH-1:0] serial_in_bits,
 
-    output        exit
+    output                     exit
 );
 
     bit __in_valid;
@@ -56,7 +69,12 @@ module SimSerial (
                 serial_out_bits,
                 __in_valid,
                 serial_in_ready,
-                __in_bits
+                __in_bits,
+                NUM_CHANNELS,
+                MEM_SIZE,
+                WORD_BYTES,
+                LINE_BYTES,
+                ID_BITS
             );
 
             __out_ready_reg <= __out_ready;

--- a/src/main/scala/SimDRAM.scala
+++ b/src/main/scala/SimDRAM.scala
@@ -5,8 +5,11 @@ import chisel3.experimental.IntParam
 import chisel3.util.HasBlackBoxResource
 import freechips.rocketchip.amba.axi4.{AXI4BundleParameters, AXI4Bundle}
 
-class SimDRAM(memSize: BigInt, lineSize: Int,
+class SimDRAM(channelId: Int, nChannels: Int,
+              memSize: BigInt, lineSize: Int,
               params: AXI4BundleParameters) extends BlackBox(Map(
+    "CHANNEL_ID" -> IntParam(channelId),
+    "NUM_CHANNELS" -> IntParam(nChannels),
     "MEM_SIZE" -> IntParam(memSize),
     "LINE_SIZE" -> IntParam(lineSize),
     "ADDR_BITS" -> IntParam(params.addrBits),


### PR DESCRIPTION
This PR attempts to solve the issue of slow program loading over HTIF by bypassing writes directly to the DRAM model, in a way similar to how FireSim currently functions. The main issue with this approach is that the memory models have to be hosted in SimSerial now, and SimDRAM needs SimSerial to be in the design in order to function properly. 