### PR TITLE
Implement loadmem functionality

### DIFF
--- a/src/main/resources/testchipip/csrc/mm.h
+++ b/src/main/resources/testchipip/csrc/mm.h
@@ -61,6 +61,8 @@ class mm_t
 
   virtual ~mm_t();
 
+  void load_mem(unsigned long start, const char *fname);
+
  protected:
   uint8_t* data;
   size_t size;
@@ -146,5 +148,4 @@ class mm_magic_t : public mm_t
   uint64_t cycle;
 };
 
-void load_mem(void** mems, const char* fn, int line_size, int nchannels);
 #endif


### PR DESCRIPTION
This is a less aggressive change than the other one. Instead of attempting to load the executable directly into memory, the user can provide a separate hex file to be loaded into a specified address. This way, SimSerial and SimDRAM don't need to be tied together. 

As a bonus, this also fixes an issue with dramsim_ini_dir not working if there are multiple SimDRAM channels. 