### PR TITLE
Add config to hang the serial TL mem off the PBus for the no-L2 case.

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -63,6 +63,10 @@ class WithDefaultSerialTL extends Config((site, here, up) => {
   ))
 })
 
+class WithSerialPBusMem extends Config((site, here, up) => {
+  case SerialTLAttachKey => up(SerialTLAttachKey, site).copy(slaveWhere = PBUS)
+})
+
 class WithSerialTLMem(
   base: BigInt = BigInt("80000000", 16),
   size: BigInt = BigInt("10000000", 16),


### PR DESCRIPTION
For configs with l2banks = 0, there is no MBUS to hang the dummy memory off of. In that case, hang it off the PBUS.