### PR TITLE
Add Support for MBUS crossings

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -5,6 +5,7 @@ import freechips.rocketchip.system.BaseConfig
 import freechips.rocketchip.config.{Parameters, Config}
 import freechips.rocketchip.tilelink._
 import freechips.rocketchip.subsystem._
+import freechips.rocketchip.diplomacy.{AsynchronousCrossing, ClockCrossingType}
 import freechips.rocketchip.unittest.UnitTests
 
 class WithRingSystemBus(
@@ -65,7 +66,14 @@ class WithDefaultSerialTL extends Config((site, here, up) => {
 
 class WithSerialPBusMem extends Config((site, here, up) => {
   case SerialTLAttachKey => up(SerialTLAttachKey, site).copy(slaveWhere = PBUS)
+
 })
+
+class WithSerialSlaveCrossingType(xType: ClockCrossingType) extends Config((site, here, up) => {
+  case SerialTLAttachKey => up(SerialTLAttachKey, site).copy(slaveCrossingType = xType)
+})
+
+class WithAsynchronousSerialSlaveCrossing extends WithSerialSlaveCrossingType(AsynchronousCrossing())
 
 class WithSerialTLMem(
   base: BigInt = BigInt("80000000", 16),

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -232,7 +232,7 @@ case object SerialTLKey extends Field[Option[SerialTLParams]](None)
 case class SerialTLAttachParams(
   masterWhere: TLBusWrapperLocation = FBUS,
   slaveWhere: TLBusWrapperLocation = MBUS,
-  slaveCrossingType: ClockCrossingType = AsynchronousCrossing()
+  slaveCrossingType: ClockCrossingType = SynchronousCrossing()
 )
 case object SerialTLAttachKey extends Field[SerialTLAttachParams](SerialTLAttachParams())
 

--- a/src/main/scala/Util.scala
+++ b/src/main/scala/Util.scala
@@ -176,3 +176,9 @@ class ClockedIO[T <: Data](private val gen: T) extends Bundle {
   val clock = Output(Clock())
   val bits = DataMirror.internal.chiselTypeClone[T](gen)
 }
+
+class ClockedAndResetIO[T <: Data](private val gen: T) extends Bundle {
+  val clock = Output(Clock())
+  val reset = Output(Reset())
+  val bits = DataMirror.internal.chiselTypeClone[T](gen)
+}


### PR DESCRIPTION
This breaks the assumption that the client and slave sides of TLSerial are int the same clock domain, instead, TLSerial couples itself to the client domain, and provides a hook to select the manager-side crossing type. 

As in #103, provides ClockedAndResetIO.

The changes contained within are probably desirable even if we don't like chipyard-side changes. 