### PR TITLE
fix Scala Chisel compile deprecation warnings

### DIFF
--- a/src/main/scala/BlockDevice.scala
+++ b/src/main/scala/BlockDevice.scala
@@ -1,8 +1,7 @@
 package testchipip
 
 import chisel3._
-import chisel3.experimental.{IO}
-import chisel3.core.IntParam
+import chisel3.experimental.{IntParam, IO}
 import chisel3.util._
 import freechips.rocketchip.config.{Field, Parameters}
 import freechips.rocketchip.subsystem.{CacheBlockBytes, BaseSubsystem, TLBusWrapperLocation, PBUS, FBUS}

--- a/src/main/scala/ClockUtil.scala
+++ b/src/main/scala/ClockUtil.scala
@@ -100,7 +100,7 @@ class ClockMutexMux(val n: Int, depth: Int, genClockGate: () => ClockGate) exten
 
     syncs.zip(gaters).foreach { case (s, g) => g.io.en := s.io.q }
 
-    syncs.zipWithIndex.foreach { case (s, i) => s.io.d := (io.sel === i.U) && !(syncs.zipWithIndex.filter(_._2 != i).map(_._1.io.q.toBool).reduce(_||_)) }
+    syncs.zipWithIndex.foreach { case (s, i) => s.io.d := (io.sel === i.U) && !(syncs.zipWithIndex.filter(_._2 != i).map(_._1.io.q.asBool).reduce(_||_)) }
 
     io.clockOut := clockOrTree(gaters.map(_.io.out))(0)
 

--- a/src/main/scala/ClockUtilTests.scala
+++ b/src/main/scala/ClockUtilTests.scala
@@ -2,8 +2,7 @@ package testchipip
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{withClock, withClockAndReset}
-import chisel3.core.IntParam
+import chisel3.experimental.IntParam
 import freechips.rocketchip.unittest._
 import freechips.rocketchip.util.{ResetCatchAndSync, EICG_wrapper}
 

--- a/src/main/scala/HeaderEnum.scala
+++ b/src/main/scala/HeaderEnum.scala
@@ -3,6 +3,7 @@ package testchipip
 import chisel3._
 import chisel3.util.log2Up
 import scala.collection.mutable.{HashMap, ListBuffer}
+import scala.language.postfixOps
 
 class HeaderEnum(val prefix: String) {
   val h = new HashMap[String,Int]

--- a/src/main/scala/NoDebug.scala
+++ b/src/main/scala/NoDebug.scala
@@ -1,7 +1,6 @@
 package testchipip
 
 import chisel3._
-import chisel3.core.Reset
 import freechips.rocketchip.subsystem.BaseSubsystem
 import freechips.rocketchip.devices.debug.HasPeripheryDebug
 import freechips.rocketchip.config.Parameters

--- a/src/main/scala/Ring.scala
+++ b/src/main/scala/Ring.scala
@@ -120,24 +120,24 @@ class TLRingNetwork(
 
   val node = TLNexusNode(
     clientFn  = { seq =>
-      seq(0).copy(
+      seq(0).v1copy(
         minLatency = seq.map(_.minLatency).min,
         clients = (TLXbar.mapInputIds(seq) zip seq) flatMap { case (range, port) =>
-          port.clients map { client => client.copy(
+          port.clients map { client => client.v1copy(
             sourceId = client.sourceId.shift(range.start)
           )}
         })
     },
     managerFn = { seq =>
       val fifoIdFactory = TLXbar.relabeler()
-      seq(0).copy(
+      seq(0).v1copy(
         minLatency = seq.map(_.minLatency).min,
         endSinkId = TLXbar.mapOutputIds(seq).map(_.end).max,
         managers = seq.flatMap { port =>
           require (port.beatBytes == seq(0).beatBytes,
             s"Ring data widths don't match: ${port.managers.map(_.name)} has ${port.beatBytes}B vs ${seq(0).managers.map(_.name)} has ${seq(0).beatBytes}B")
           val fifoIdMapper = fifoIdFactory()
-          port.managers map { manager => manager.copy(
+          port.managers map { manager => manager.v1copy(
             fifoId = manager.fifoId.map(fifoIdMapper(_))
           )}
         })

--- a/src/main/scala/Serdes.scala
+++ b/src/main/scala/Serdes.scala
@@ -479,7 +479,7 @@ class TLSerdes(w: Int, params: Seq[TLManagerParameters], beatBytes: Int = 8)
 
   val node = TLManagerNode(params.map(
     manager =>
-      TLManagerPortParameters(
+      TLSlavePortParameters.v1(
         managers = Seq(manager),
         beatBytes = beatBytes)))
 
@@ -521,7 +521,7 @@ class TLDesser(w: Int, params: Seq[TLClientParameters])
     (implicit p: Parameters) extends LazyModule {
 
   val node = TLClientNode(params.map(client =>
-      TLClientPortParameters(Seq(client))))
+      TLMasterPortParameters.v1(Seq(client))))
 
   lazy val module = new LazyModuleImp(this) {
     val nChannels = params.size

--- a/src/main/scala/Switcher.scala
+++ b/src/main/scala/Switcher.scala
@@ -104,8 +104,8 @@ class TLSwitcher(
   val device = new SimpleDevice("switcher", Seq("ucb-bar,switcher"))
 
   val innode = TLManagerNode(Seq.tabulate(inPortN) { i =>
-    TLManagerPortParameters(
-      Seq(TLManagerParameters(
+    TLSlavePortParameters.v1(
+      Seq(TLSlaveParameters.v1(
         address    = address(i),
         resources  = device.reg("mem"),
         regionType = if (cacheable) RegionType.UNCACHED
@@ -119,7 +119,7 @@ class TLSwitcher(
 
   val outnodes = outPortN.map(n =>
     TLClientNode(Seq.tabulate(n) { i =>
-      TLClientPortParameters(Seq(TLClientParameters(
+      TLMasterPortParameters.v1(Seq(TLMasterParameters.v1(
         name = s"switch_$i", sourceId = IdRange(0, 1 << idBits))))
     })): Seq[TLClientNode]
 

--- a/src/main/scala/Unittests.scala
+++ b/src/main/scala/Unittests.scala
@@ -135,7 +135,7 @@ class SerdesTest(implicit p: Parameters) extends LazyModule {
 
   val serdes = LazyModule(new TLSerdes(
     w = serWidth,
-    params = Seq(TLManagerParameters(
+    params = Seq(TLSlaveParameters.v1(
       address = Seq(AddressSet(0, 0xffff)),
       regionType = RegionType.UNCACHED,
       supportsGet = TransferSizes(1, lineBytes),
@@ -144,7 +144,7 @@ class SerdesTest(implicit p: Parameters) extends LazyModule {
 
   val desser = LazyModule(new TLDesser(
     w = serWidth,
-    params = Seq(TLClientParameters(
+    params = Seq(TLMasterParameters.v1(
       name = "tl-desser",
       sourceId = IdRange(0, 1 << idBits)))))
 
@@ -191,13 +191,13 @@ class BidirectionalSerdesTest(implicit p: Parameters) extends LazyModule {
 
   val serdes = LazyModule(new TLSerdesser(
     w = serWidth,
-    clientPortParams = TLClientPortParameters(
-      clients = Seq(TLClientParameters(
+    clientPortParams = TLMasterPortParameters.v1(
+      clients = Seq(TLMasterParameters.v1(
         name = "tl-desser",
         sourceId = IdRange(0, 1 << idBits)))
     ),
-    managerPortParams = TLManagerPortParameters(
-      managers = Seq(TLManagerParameters(
+    managerPortParams = TLSlavePortParameters.v1(
+      managers = Seq(TLSlaveParameters.v1(
         address = Seq(AddressSet(0, 0xffff)),
         regionType = RegionType.UNCACHED,
         supportsGet = TransferSizes(1, lineBytes),

--- a/src/main/scala/Util.scala
+++ b/src/main/scala/Util.scala
@@ -130,15 +130,15 @@ object WordSync {
 object TLHelper {
   def makeClientNode(name: String, sourceId: IdRange)
                     (implicit valName: ValName): TLClientNode =
-    makeClientNode(TLClientParameters(name, sourceId))
+    makeClientNode(TLMasterParameters.v1(name, sourceId))
 
   def makeClientNode(params: TLClientParameters)
                     (implicit valName: ValName): TLClientNode =
-    TLClientNode(Seq(TLClientPortParameters(Seq(params))))
+    TLClientNode(Seq(TLMasterPortParameters.v1(Seq(params))))
 
   def makeManagerNode(beatBytes: Int, params: TLManagerParameters)
                      (implicit valName: ValName): TLManagerNode =
-    TLManagerNode(Seq(TLManagerPortParameters(Seq(params), beatBytes)))
+    TLManagerNode(Seq(TLSlavePortParameters.v1(Seq(params), beatBytes)))
 
   def latency(lat: Int, node: TLOutwardNode)(implicit p: Parameters): TLOutwardNode =
     TLBuffer.chain(lat).foldRight(node)(_ :=* _)


### PR DESCRIPTION
**Type of change**: paying off technical debt

**Impact**: no functional change

**What was changed**
fix compile warnings:
```
[warn] /testchipip/src/main/scala/HeaderEnum.scala:10:103: postfix operator mkString should be enabled
[warn] by making the implicit value scala.language.postfixOps visible.
[warn] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[warn] or by setting the compiler option -language:postfixOps.
[warn] See the Scaladoc for value scala.language.postfixOps for a discussion
[warn] why the feature should be explicitly enabled.
[warn]     h.toSeq.sortBy(_._2).map { case (n,i) => s"#define ${prefix.toUpperCase}_${n.toUpperCase} $i\n" } mkString
[warn]                                                                                                       ^
[warn] /testchipip/src/main/scala/BlockDevice.scala:421:23: value IntParam in package core is deprecated (since 3.2): Use the version in chisel3.experimental._
[warn]     Map("TAG_BITS" -> IntParam(log2Up(config.get.nTrackers)))
[warn]                       ^
[warn] /testchipip/src/main/scala/ClockUtil.scala:103:132: method do_toBool in class Bits is deprecated (since 3.2): Use asBool instead
[warn]     syncs.zipWithIndex.foreach { case (s, i) => s.io.d := (io.sel === i.U) && !(syncs.zipWithIndex.filter(_._2 != i).map(_._1.io.q.toBool).reduce(_||_)) }
[warn]                                                                                                                                    ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:28:17: value withClockAndReset in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]     val state = withClockAndReset(clocks(0), syncReset) { RegInit(sReset) }
[warn]                 ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:30:5: value withClock in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]     withClock(mux.io.clockOut) {
[warn]     ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:34:5: value withClockAndReset in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]     withClockAndReset(clocks(0), syncReset) {
[warn]     ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:73:19: value withClock in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]     val divider = withClock(myClock) { Module(new ClockDivider(log2Ceil(divs.max))) }
[warn]                   ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:77:17: value withClockAndReset in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]     val state = withClockAndReset(myClock, syncReset) { RegInit(sReset) }
[warn]                 ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:79:5: value withClockAndReset in package experimental is deprecated (since 3.2): Use the version in chisel3._
[warn]     withClockAndReset(myClock, syncReset) {
[warn]     ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:107:22: value IntParam in package core is deprecated (since 3.2): Use the version in chisel3.experimental._
[warn]     "minperiodps" -> IntParam(minperiodps),
[warn]                      ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:108:22: value IntParam in package core is deprecated (since 3.2): Use the version in chisel3.experimental._
[warn]     "maxperiodps" -> IntParam(maxperiodps.getOrElse(BigInt(0)))
[warn]                      ^
[warn] /testchipip/src/main/scala/ClockUtilTests.scala:118:72: value IntParam in package core is deprecated (since 3.2): Use the version in chisel3.experimental._
[warn] class ClockGenerator(periodps: Int) extends BlackBox(Map("periodps" -> IntParam(periodps))) {
[warn]                                                                        ^
[warn] /testchipip/src/main/scala/NoDebug.scala:17:14: type Reset in package core is deprecated (since 3.2): Use the version in chisel3._
[warn]   val reset: Reset
[warn]              ^
[warn] /testchipip/src/main/scala/Ring.scala:126:47: method copy in class TLMasterParameters is deprecated: Use v1copy instead of copy
[warn]           port.clients map { client => client.copy(
[warn]                                               ^
[warn] /testchipip/src/main/scala/Ring.scala:123:14: method copy in class TLMasterPortParameters is deprecated: Use v1copy instead of copy
[warn]       seq(0).copy(
[warn]              ^
[warn] /testchipip/src/main/scala/Ring.scala:140:50: method copy in class TLSlaveParameters is deprecated: Use v1copy instead of copy
[warn]           port.managers map { manager => manager.copy(
[warn]                                                  ^
[warn] /testchipip/src/main/scala/Ring.scala:133:14: method copy in class TLSlavePortParameters is deprecated: Use v1copy instead of copy
[warn]       seq(0).copy(
[warn]              ^
[warn] /testchipip/src/main/scala/Serdes.scala:490:7: method apply in object TLManagerPortParameters is deprecated: Use TLSlavePortParameters.v1 instead of TLManagerPortParameters
[warn]       TLManagerPortParameters(
[warn]       ^
[warn] /testchipip/src/main/scala/Serdes.scala:532:7: method apply in object TLClientPortParameters is deprecated: Use TLMasterPortParameters.v1 instead of TLClientPortParameters
[warn]       TLClientPortParameters(Seq(client))))
[warn]       ^
[warn] /testchipip/src/main/scala/Serdes.scala:580:9: method apply in object TLClientPortParameters is deprecated: Use TLMasterPortParameters.v1 instead of TLClientPortParameters
[warn]     Seq(TLClientPortParameters(Seq(clientParams))))
[warn]         ^
[warn] /testchipip/src/main/scala/Serdes.scala:583:9: method apply in object TLManagerPortParameters is deprecated: Use TLSlavePortParameters.v1 instead of TLManagerPortParameters
[warn]     Seq(TLManagerPortParameters(
[warn]         ^
[warn] /testchipip/src/main/scala/Switcher.scala:107:5: method apply in object TLManagerPortParameters is deprecated: Use TLSlavePortParameters.v1 instead of TLManagerPortParameters
[warn]     TLManagerPortParameters(
[warn]     ^
[warn] /testchipip/src/main/scala/Switcher.scala:108:11: method apply in object TLManagerParameters is deprecated: Use TLSlaveParameters.v1 instead of TLManagerParameters
[warn]       Seq(TLManagerParameters(
[warn]           ^
[warn] /testchipip/src/main/scala/Switcher.scala:122:7: method apply in object TLClientPortParameters is deprecated: Use TLMasterPortParameters.v1 instead of TLClientPortParameters
[warn]       TLClientPortParameters(Seq(TLClientParameters(
[warn]       ^
[warn] /testchipip/src/main/scala/Switcher.scala:122:34: method apply in object TLClientParameters is deprecated: Use TLMasterParameters.v1 instead of TLClientParameters
[warn]       TLClientPortParameters(Seq(TLClientParameters(
[warn]                                  ^
[warn] /testchipip/src/main/scala/Unittests.scala:138:18: method apply in object TLManagerParameters is deprecated: Use TLSlaveParameters.v1 instead of TLManagerParameters
[warn]     params = Seq(TLManagerParameters(
[warn]                  ^
[warn] /testchipip/src/main/scala/Unittests.scala:147:18: method apply in object TLClientParameters is deprecated: Use TLMasterParameters.v1 instead of TLClientParameters
[warn]     params = Seq(TLClientParameters(
[warn]                  ^
[warn] /testchipip/src/main/scala/Unittests.scala:194:20: method apply in object TLClientParameters is deprecated: Use TLMasterParameters.v1 instead of TLClientParameters
[warn]     clientParams = TLClientParameters(
[warn]                    ^
[warn] /testchipip/src/main/scala/Unittests.scala:197:21: method apply in object TLManagerParameters is deprecated: Use TLSlaveParameters.v1 instead of TLManagerParameters
[warn]     managerParams = TLManagerParameters(
[warn]                     ^
[warn] /testchipip/src/main/scala/Util.scala:132:20: method apply in object TLClientParameters is deprecated: Use TLMasterParameters.v1 instead of TLClientParameters
[warn]     makeClientNode(TLClientParameters(name, sourceId))
[warn]                    ^
[warn] /testchipip/src/main/scala/Util.scala:136:22: method apply in object TLClientPortParameters is deprecated: Use TLMasterPortParameters.v1 instead of TLClientPortParameters
[warn]     TLClientNode(Seq(TLClientPortParameters(Seq(params))))
[warn]                      ^
[warn] /testchipip/src/main/scala/Util.scala:140:23: method apply in object TLManagerPortParameters is deprecated: Use TLSlavePortParameters.v1 instead of TLManagerPortParameters
[warn]     TLManagerNode(Seq(TLManagerPortParameters(Seq(params), beatBytes)))
[warn]                       ^
```