### PR TITLE
Chisel deprecated: setResource -> addResource

### DIFF
--- a/src/main/scala/BlockDevice.scala
+++ b/src/main/scala/BlockDevice.scala
@@ -438,10 +438,10 @@ class SimBlockDevice(implicit p: Parameters)
     val bdev = Flipped(new BlockDeviceIO)
   })
 
-  setResource("/testchipip/vsrc/SimBlockDevice.v")
-  setResource("/testchipip/csrc/SimBlockDevice.cc")
-  setResource("/testchipip/csrc/blkdev.cc")
-  setResource("/testchipip/csrc/blkdev.h")
+  addResource("/testchipip/vsrc/SimBlockDevice.v")
+  addResource("/testchipip/csrc/SimBlockDevice.cc")
+  addResource("/testchipip/csrc/blkdev.cc")
+  addResource("/testchipip/csrc/blkdev.h")
 }
 
 trait CanHavePeripheryBlockDevice { this: BaseSubsystem =>

--- a/src/main/scala/HeaderEnum.scala
+++ b/src/main/scala/HeaderEnum.scala
@@ -3,12 +3,11 @@ package testchipip
 import chisel3._
 import chisel3.util.log2Up
 import scala.collection.mutable.{HashMap, ListBuffer}
-import scala.language.postfixOps
 
 class HeaderEnum(val prefix: String) {
   val h = new HashMap[String,Int]
   def makeHeader(): String = {
-    h.toSeq.sortBy(_._2).map { case (n,i) => s"#define ${prefix.toUpperCase}_${n.toUpperCase} $i\n" } mkString
+    h.toSeq.sortBy(_._2).map { case (n,i) => s"#define ${prefix.toUpperCase}_${n.toUpperCase} $i\n" }.mkString
   }
   def apply(s: String): UInt = h(s).U(log2Up(h.size).W)
 }


### PR DESCRIPTION
**Related issue**: follow-on to https://github.com/ucb-bar/testchipip/pull/108

**Type of change**: paying off technical debt

**Impact**: no functional change

**What was changed**
fix compile warnings:
```
[warn] /testchipip/src/main/scala/BlockDevice.scala:433:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/testchipip/vsrc/SimBlockDevice.v")
[warn]   ^
[warn] /testchipip/src/main/scala/BlockDevice.scala:434:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/testchipip/csrc/SimBlockDevice.cc")
[warn]   ^
[warn] /testchipip/src/main/scala/BlockDevice.scala:435:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/testchipip/csrc/blkdev.cc")
[warn]   ^
[warn] /testchipip/src/main/scala/BlockDevice.scala:436:3: method setResource in trait HasBlackBoxResource is deprecated (since 3.2): Use addResource instead
[warn]   setResource("/testchipip/csrc/blkdev.h")
[warn]   ^
[warn] /testchipip/src/main/scala/HeaderEnum.scala:10:103: postfix operator mkString should be enabled
[warn] by making the implicit value scala.language.postfixOps visible.
[warn] This can be achieved by adding the import clause 'import scala.language.postfixOps'
[warn] or by setting the compiler option -language:postfixOps.
[warn] See the Scaladoc for value scala.language.postfixOps for a discussion
[warn] why the feature should be explicitly enabled.
[warn]     h.toSeq.sortBy(_._2).map { case (n,i) => s"#define ${prefix.toUpperCase}_${n.toUpperCase} $i\n" } mkString
[warn]                                                                                                       ^
```