### PR TITLE
add default member initializer for mm_dramsim2_t::clock_hz

### DIFF
--- a/src/main/resources/testchipip/csrc/mm_dramsim2.h
+++ b/src/main/resources/testchipip/csrc/mm_dramsim2.h
@@ -122,7 +122,7 @@ class mm_dramsim2_t : public mm_t
   std::vector<bool> write_id_busy;
   std::list<mm_req_t> rreq_queue;
 
-  uint64_t clock_hz;
+  uint64_t clock_hz = 0;
 
   void read_complete(unsigned id, uint64_t address, uint64_t clock_cycle);
   void write_complete(unsigned id, uint64_t address, uint64_t clock_cycle);


### PR DESCRIPTION
in firesim/firesim#764 MIDAS-level simulation has been timing out.  This
is being caused by uninitialized value of clock_hz.  In general all
non-static data members should be given default member initializers
to guard against cases like this where several of the constructor
signatures of mm_dramsim2_t fail to initialize clock_hz.