### PR TITLE
Summary: adding <stdexcept> to testchip_tsi.cc

### DIFF
--- a/src/main/resources/testchipip/csrc/testchip_tsi.cc
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.cc
@@ -1,4 +1,5 @@
 #include "testchip_tsi.h"
+#include <stdexcept>
 
 testchip_tsi_t::testchip_tsi_t(int argc, char** argv, bool can_have_loadmem) : tsi_t(argc, argv)
 {


### PR DESCRIPTION
Not sure if you guys want to merge this, but I decided to let you know that I had to include <stdexcept> in testchip_tsi.cc on my side to be able to compile VCS simulator.

Commit details: compilation of the VCS simulator failed with the complains related to `throw std::invalid_argument()`. Addition of the <stdexcept> resolves the issue.