### PR TITLE
Support multi-thread VCS simv option like FGP, Xprof etc.

### DIFF
--- a/src/main/resources/testchipip/csrc/SimSerial.cc
+++ b/src/main/resources/testchipip/csrc/SimSerial.cc
@@ -6,6 +6,24 @@
 
 testchip_tsi_t *tsi = NULL;
 
+// Remove VCS simv option from argv if it match pattern -X???=
+void remove_vcs_simv_opt(int & argc, char **& argv){
+    int idx = 0;
+    while(idx < argc){
+        std::string str = std::string(argv[idx]);
+        if(str.length() > 1 && str[0] == '-' && str[1] != '-' && str.find('=') != std::string::npos){
+            // Found -????=???? as VCS simv option
+            for(int i = idx; i < argc - 1; i++){
+                // Remove the current option
+                argv[i] = argv[i + 1];
+            }
+            argc--;
+        }else{
+            idx++;
+        }
+    }
+}
+
 extern "C" int serial_tick(
         unsigned char out_valid,
         unsigned char *out_ready,
@@ -23,6 +41,9 @@ extern "C" int serial_tick(
         s_vpi_vlog_info info;
         if (!vpi_get_vlog_info(&info))
           abort();
+
+	  // Prevent simv option enter htif
+	  remove_vcs_simv_opt(info.argc, info.argv);
 
         // TODO: We should somehow inspect whether or not our backing memory supports loadmem, instead of unconditionally setting it to true
         tsi = new testchip_tsi_t(info.argc, info.argv, true);

--- a/src/main/resources/testchipip/csrc/testchip_tsi.h
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.h
@@ -3,6 +3,7 @@
 
 #include <fesvr/tsi.h>
 #include <fesvr/htif.h>
+#include <stdexcept>
 
 class testchip_tsi_t : public tsi_t
 {


### PR DESCRIPTION
According to https://github.com/ucb-bar/chipyard/issues/1081 and per @jerryz123 's suggestion, I remove the VCS simv option from argv before entering base htif constructor. It is tested under chipyard. 

Command like `make EXTRA_SIM_FLAGS="-fgp=num_threads:2 -Xdprof=timeline"` will enable multi-thread VCS simulation via two step flow:
```
% vcs -fgp -full64 <otherOptions> 
% simv -fgp=num_threads:<value>
```

Additionally, a minor fix mentioned https://github.com/ucb-bar/testchipip/pull/134 due to compilation error.