### PR TITLE
Idle tsi in the target thread.

### DIFF
--- a/src/main/resources/testchipip/csrc/testchip_tsi.h
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.h
@@ -18,6 +18,7 @@ class testchip_tsi_t : public tsi_t
     tsi_t::load_program();
     is_loadmem = false;
   }
+  void idle() { switch_to_target(); }
 
  protected:
   virtual void load_mem_write(addr_t taddr, size_t nbytes, const void* src) { };


### PR DESCRIPTION
Switch to the target thread when `htif` `idle`s. This enables continual execution of the target even if htif isn't working correctly.