### PR TITLE
Updating build.sbt as a precursor to updating Maven

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,7 @@ version := "1.0-SNAPSHOT"
 scalaVersion := "2.12.10"
 
 scalacOptions += "-Xsource:2.11"
+lazy val sifiveblocks = RootProject(uri("https://github.com/sifive/sifive-blocks.git"))
 
 lazy val root = (project in file "."))
     .dependsOn(sifiveblocks)
@@ -49,6 +50,5 @@ lazy val root = (project in file "."))
         Resolver.mavenLocal)
     )
 
-lazy val sifiveblocks = RootProject(uri("https://github.com/sifive/sifive-blocks.git"))
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -2,45 +2,53 @@ organization := "edu.berkeley.cs"
 
 version := "1.0-SNAPSHOT"
 
-name := "testchipip"
 
 scalaVersion := "2.12.10"
 
 scalacOptions += "-Xsource:2.11"
 
-libraryDependencies += "edu.berkeley.cs" %% "rocketchip" % "1.5-SNAPSHOT"
+lazy val root = (project in file "."))
+    .dependsOn(sifiveblocks)
+    .settings(
+      name := "testchipip"
+      libraryDependencies += "edu.berkeley.cs" %% "rocketchip" % "1.5-SNAPSHOT"
 
-publishMavenStyle := true
+      publishMavenStyle := true
 
-publishArtifact in Test := false
+      publishArtifact in Test := false
 
-pomIncludeRepository := { x => false }
+      pomIncludeRepository := { x => false }
 
-pomExtra := <url>https://github.com/ucb-bar/testchipip</url>
-<licenses>
-  <license>
-    <name>BSD-style</name>
-      <url>http://www.opensource.org/licenses/bsd-license.php</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-  <scm>
-    <url>https://github.com/ucb-bar/testchipip.git</url>
-    <connection>scm:git:github.com/ucb-bar/testchipip.git</connection>
-  </scm>
+      pomExtra := <url>https://github.com/ucb-bar/testchipip</url>
+      <licenses>
+        <license>
+          <name>BSD-style</name>
+            <url>http://www.opensource.org/licenses/bsd-license.php</url>
+            <distribution>repo</distribution>
+          </license>
+        </licenses>
+        <scm>
+          <url>https://github.com/ucb-bar/testchipip.git</url>
+          <connection>scm:git:github.com/ucb-bar/testchipip.git</connection>
+        </scm>
 
-publishTo := {
-  val v = version.value
-  val nexus = "https://oss.sonatype.org/"
-  if (v.trim.endsWith("SNAPSHOT")) {
-    Some("snapshots" at nexus + "content/repositories/snapshots")
-  }
-  else {
-    Some("releases" at nexus + "service/local/staging/deploy/maven2")
-  }
-}
+      publishTo := {
+        val v = version.value
+        val nexus = "https://oss.sonatype.org/"
+        if (v.trim.endsWith("SNAPSHOT")) {
+          Some("snapshots" at nexus + "content/repositories/snapshots")
+        }
+        else {
+          Some("releases" at nexus + "service/local/staging/deploy/maven2")
+        }
+      }
 
-resolvers ++= Seq(
-  Resolver.sonatypeRepo("snapshots"),
-  Resolver.sonatypeRepo("releases"),
-  Resolver.mavenLocal)
+      resolvers ++= Seq(
+        Resolver.sonatypeRepo("snapshots"),
+        Resolver.sonatypeRepo("releases"),
+        Resolver.mavenLocal)
+    )
+
+lazy val sifiveblocks = RootProject(uri("https://github.com/sifive/sifive-blocks.git"))
+
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,24 +1,21 @@
-organization := "edu.berkeley.cs"
+ThisBuild / organization := "edu.berkeley.cs"
+ThisBuild / version := "1.0-SNAPSHOT"
+ThisBuild / scalaVersion := "2.12.10"
 
-version := "1.0-SNAPSHOT"
-
-
-scalaVersion := "2.12.10"
-
-scalacOptions += "-Xsource:2.11"
 lazy val sifiveblocks = RootProject(uri("https://github.com/sifive/sifive-blocks.git"))
 
 lazy val root = (project in file "."))
     .dependsOn(sifiveblocks)
     .settings(
-      name := "testchipip"
-      libraryDependencies += "edu.berkeley.cs" %% "rocketchip" % "1.5-SNAPSHOT"
+      name := "testchipip",
+	  scalacOptions += "-Xsource:2.11",
+      libraryDependencies += "edu.berkeley.cs" %% "rocketchip" % "1.5-SNAPSHOT",
 
-      publishMavenStyle := true
+      publishMavenStyle := true,
 
-      publishArtifact in Test := false
+      publishArtifact in Test := false,
 
-      pomIncludeRepository := { x => false }
+      pomIncludeRepository := { x => false },
 
       pomExtra := <url>https://github.com/ucb-bar/testchipip</url>
       <licenses>
@@ -31,7 +28,7 @@ lazy val root = (project in file "."))
         <scm>
           <url>https://github.com/ucb-bar/testchipip.git</url>
           <connection>scm:git:github.com/ucb-bar/testchipip.git</connection>
-        </scm>
+        </scm>,
 
       publishTo := {
         val v = version.value
@@ -42,12 +39,12 @@ lazy val root = (project in file "."))
         else {
           Some("releases" at nexus + "service/local/staging/deploy/maven2")
         }
-      }
+      },
 
       resolvers ++= Seq(
         Resolver.sonatypeRepo("snapshots"),
         Resolver.sonatypeRepo("releases"),
-        Resolver.mavenLocal)
+        Resolver.mavenLocal),
     )
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,15 +1,15 @@
 ThisBuild / organization := "edu.berkeley.cs"
-ThisBuild / version := "1.0-SNAPSHOT"
+ThisBuild / version := "1.1"
 ThisBuild / scalaVersion := "2.12.10"
 
-lazy val sifiveblocks = RootProject(uri("https://github.com/sifive/sifive-blocks.git"))
 
-lazy val root = (project in file "."))
-    .dependsOn(sifiveblocks)
+lazy val root = (project in file("."))
     .settings(
       name := "testchipip",
 	  scalacOptions += "-Xsource:2.11",
       libraryDependencies += "edu.berkeley.cs" %% "rocketchip" % "1.5-SNAPSHOT",
+      libraryDependencies += "edu.berkeley.cs" %% "chisel3" % "3.5.5",
+      libraryDependencies += "edu.berkeley.cs" %% "rocketchipblocks" % "1.0-SNAPSHOT",
 
       publishMavenStyle := true,
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ scalaVersion := "2.12.10"
 
 scalacOptions += "-Xsource:2.11"
 
-libraryDependencies += "edu.berkeley.cs" %% "rocketchip" % "1.2.+"
+libraryDependencies += "edu.berkeley.cs" %% "rocketchip" % "1.5-SNAPSHOT"
 
 publishMavenStyle := true
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.13
+sbt.version=1.8.0


### PR DESCRIPTION
This commit bumps build.sbt in preperation for bumping the published version on maven, which is ~3 years old at this point.

Replaces #152