### PR TITLE
TSI-over-UART

### DIFF
--- a/src/main/resources/testchipip/csrc/SimUART.cc
+++ b/src/main/resources/testchipip/csrc/SimUART.cc
@@ -12,10 +12,20 @@ extern "C" void uart_init(
         const char *filename,
         int uartno)
 {
+  bool use_pty = false;
+  s_vpi_vlog_info vinfo;
+  if (!vpi_get_vlog_info(&vinfo))
+    abort();
+  for (int i = 1; i < vinfo.argc; i++) {
+    std::string arg(vinfo.argv[i]);
+    if (arg == "+uart-pty")
+      use_pty = true;
+    }
+
     if (strlen(filename) != 0)
-        uart = new uart_t(filename, uartno);
+      uart = new uart_t(filename, uartno, use_pty);
     else
-        uart = new uart_t(0, uartno);
+      uart = new uart_t(0, uartno, use_pty);
 }
 
 extern "C" void uart_tick(

--- a/src/main/resources/testchipip/csrc/testchip_tsi.cc
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.cc
@@ -6,6 +6,7 @@ testchip_tsi_t::testchip_tsi_t(int argc, char** argv, bool can_have_loadmem) : t
   has_loadmem = false;
   init_writes = std::vector<std::pair<uint64_t, uint32_t>>();
   write_hart0_msip = true;
+  is_loadmem = false;
 
   std::vector<std::string> args(argv + 1, argv + argc);
   for (auto& arg : args) {

--- a/src/main/resources/testchipip/csrc/testchip_tsi.cc
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.cc
@@ -57,6 +57,7 @@ void testchip_tsi_t::reset()
     if (p.store) {
       fprintf(stderr, "Writing %lx with %x\n", p.address, p.stdata);
       write_chunk(p.address, sizeof(uint32_t), &p.stdata);
+      fprintf(stderr, "Done writing %lx with %x\n", p.address, p.stdata);
     } else {
       fprintf(stderr, "Reading %lx ...", p.address);
       uint32_t rdata = 0;

--- a/src/main/resources/testchipip/csrc/testchip_tsi.h
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.h
@@ -6,6 +6,12 @@
 #include <fesvr/tsi.h>
 #include <fesvr/htif.h>
 
+struct init_access_t {
+  uint64_t address;
+  uint32_t stdata;
+  bool store;
+};
+
 class testchip_tsi_t : public tsi_t
 {
  public:
@@ -32,6 +38,6 @@ class testchip_tsi_t : public tsi_t
 
   bool is_loadmem;
   bool write_hart0_msip;
-  std::vector<std::pair<uint64_t, uint32_t>> init_writes;
+  std::vector<init_access_t> init_accesses;
 };
 #endif

--- a/src/main/resources/testchipip/csrc/uart.cc
+++ b/src/main/resources/testchipip/csrc/uart.cc
@@ -37,13 +37,13 @@ void sighand(int s) {
 #warning "The UARTAdapter is untested with Windows. Many features expected to be broken."
 #endif
 
-uart_t::uart_t(const char* filename_prefix, int uartno)
+uart_t::uart_t(const char* filename_prefix, int uartno, bool use_pty)
 {
     this->inputfd = 0;
     this->outputfd = 0;
     this->print_file = false;
 
-    if (uartno == 0) {
+    if (uartno == 0 && !use_pty) {
         // signal handler so ctrl-c doesn't kill simulation when UART is attached
         // to stdin/stdout
         struct sigaction sigIntHandler;

--- a/src/main/resources/testchipip/csrc/uart.h
+++ b/src/main/resources/testchipip/csrc/uart.h
@@ -10,7 +10,8 @@ class uart_t
     public:
         uart_t(
             const char* filename_prefix,
-            int uartno);
+            int uartno,
+            bool use_pty);
         ~uart_t();
         void tick(
             unsigned char out_valid,

--- a/src/main/resources/testchipip/vsrc/SimUART.v
+++ b/src/main/resources/testchipip/vsrc/SimUART.v
@@ -29,49 +29,62 @@ module SimUART #(UARTNO) (
     output [`DATA_WIDTH-1:0] serial_in_bits
 );
 
-    bit __in_valid;
-    bit __out_ready;
-    byte __in_bits;
-    string __uartlog;
-    int __uartno;
+   wire                      __in_ready;
+   bit                       __in_valid;
+   byte                      __in_bits;
 
-    initial begin
-        $value$plusargs("uartlog=%s", __uartlog);
-        uart_init(__uartlog, __uartno);
-    end
+   bit                       __out_ready;
+   wire                      __out_valid;
+   wire [`DATA_WIDTH-1:0]    __out_bits;
 
-    reg __in_valid_reg;
-    reg __out_ready_reg;
-    reg [`DATA_WIDTH-1:0] __in_bits_reg;
+   string                    __uartlog;
+   int                       __uartno;
 
-    assign serial_in_valid  = __in_valid_reg;
-    assign serial_in_bits   = __in_bits_reg;
-    assign serial_out_ready = __out_ready_reg;
+   initial begin
+      $value$plusargs("uartlog=%s", __uartlog);
+      uart_init(__uartlog, __uartno);
+   end
 
-    // Evaluate the signals on the positive edge
-    always @(posedge clock) begin
-        if (reset) begin
-            __in_valid = 0;
-            __out_ready = 0;
+   reg __in_valid_reg;
+   reg [`DATA_WIDTH-1:0] __in_bits_reg;
 
-            __in_valid_reg <= 0;
-            __in_bits_reg <= 0;
-            __out_ready_reg <= 0;
-            __uartno = UARTNO;
-        end else begin
-            uart_tick(
-                serial_out_valid,
-                __out_ready,
-                serial_out_bits,
-                __in_valid,
-                serial_in_ready,
-                __in_bits
-            );
+   reg                   __out_ready_reg;
 
-            __out_ready_reg <= __out_ready;
-            __in_valid_reg  <= __in_valid;
-            __in_bits_reg   <= __in_bits;
-        end
-    end
+
+   
+   // Evaluate the signals on the positive edge
+   always @(posedge clock) begin
+      if (reset) begin
+         __in_valid = 0;
+         __out_ready = 0;
+
+         __in_valid_reg <= 0;
+         __in_bits_reg <= 0;
+         __out_ready_reg <= 0;
+         __uartno = UARTNO;
+      end else begin
+         uart_tick(
+                   __out_valid,
+                   __out_ready,
+                   __out_bits,
+                   __in_valid,
+                   __in_ready,
+                   __in_bits
+                   );
+
+         __out_ready_reg <= __out_ready;
+         __in_valid_reg  <= __in_valid;
+         __in_bits_reg   <= __in_bits;
+      end
+   end // always @ (posedge clock)
+
+   assign serial_in_valid  = __in_valid_reg;
+   assign serial_in_bits   = __in_bits_reg;
+   assign __in_ready = serial_in_ready;
+
+   assign serial_out_ready = __out_ready_reg;
+   assign __out_valid = serial_out_valid;
+   assign __out_bits = serial_out_bits;
+
 
 endmodule

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -117,3 +117,7 @@ class WithSerialTLROMFile(file: String) extends Config((site, here, up) => {
 class WithTilesStartInReset(harts: Int*) extends Config((site, here, up) => {
   case TileResetCtrlKey => up(TileResetCtrlKey, site).copy(initResetHarts = up(TileResetCtrlKey, site).initResetHarts ++ harts)
 })
+
+class WithNoSerialTL extends Config((site, here, up) => {
+  case SerialTLKey => None
+})

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -137,6 +137,7 @@ class SerialAdapterModule(outer: SerialAdapter) extends LazyModuleImp(outer) {
   val w = SERIAL_TSI_WIDTH
   val io = IO(new Bundle {
     val serial = new SerialIO(w)
+    val state = Output(UInt())
   })
 
   val (mem, edge) = outer.node.out(0)
@@ -165,6 +166,7 @@ class SerialAdapterModule(outer: SerialAdapter) extends LazyModuleImp(outer) {
        s_read_req  :: s_read_data :: s_read_body ::
        s_write_body :: s_write_data :: s_write_ack :: Nil) = Enum(9)
   val state = RegInit(s_cmd)
+  io.state := state
 
   io.serial.in.ready := state.isOneOf(s_cmd, s_addr, s_len, s_write_body)
   io.serial.out.valid := state === s_read_body
@@ -477,11 +479,13 @@ class SerialRAM(
     val io = IO(new Bundle {
       val ser = Flipped(new SerialIO(w))
       val tsi_ser = new SerialIO(SERIAL_TSI_WIDTH)
+      val adapter_state = Output(UInt())
     })
 
     serdesser.module.io.ser.in <> io.ser.out
     io.ser.in <> serdesser.module.io.ser.out
     io.tsi_ser <> adapter.module.io.serial
+    io.adapter_state := adapter.module.io.state
   }
 }
 

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -608,67 +608,35 @@ class MultiClockSerialAXIRAM(
   }
 }
 
-
-class UARTToTSI(freq: BigInt, uartParams: UARTParams) extends Module {
+class SerialWidthAdapter(narrowW: Int, wideW: Int) extends Module {
+  require(wideW > narrowW)
+  require(wideW % narrowW == 0)
   val io = IO(new Bundle {
-    val uart = new UARTPortIO(uartParams)
-    val serial = new SerialIO(SERIAL_TSI_WIDTH)
-    val dropped = Output(Bool()) // No flow control, so dropping a beat means we're screwed
+    val narrow = new SerialIO(narrowW)
+    val wide = new SerialIO(wideW)
   })
 
-  val rxm = Module(new UARTRx(uartParams))
-  val rxq = Module(new Queue(UInt(uartParams.dataBits.W), uartParams.nRxEntries))
-  val txm = Module(new UARTTx(uartParams))
-  val txq = Module(new Queue(UInt(uartParams.dataBits.W), uartParams.nTxEntries))
+  val beats = wideW / narrowW
 
-  val div = (freq / uartParams.initBaudRate).toInt
+  val narrow_beats = RegInit(0.U(log2Ceil(beats).W))
+  val narrow_last_beat = narrow_beats === (beats-1).U
+  val narrow_data = Reg(Vec(beats-1, UInt(narrowW.W)))
 
-  val dropped = RegInit(false.B)
-  io.dropped := dropped
-  rxm.io.en := true.B
-  rxm.io.in := io.uart.rxd
-  rxm.io.div := div.U
-  rxq.io.enq.valid := rxm.io.out.valid
-  rxq.io.enq.bits := rxm.io.out.bits
-  when (rxq.io.enq.valid) { assert(rxq.io.enq.ready) }
-  when (rxq.io.enq.valid && !rxq.io.enq.ready) { dropped := true.B } // no flow control
-  dontTouch(rxm.io)
+  val wide_beats = RegInit(0.U(log2Ceil(beats).W))
+  val wide_last_beat = wide_beats === (beats-1).U
 
-  txm.io.en := true.B
-  txm.io.in <> txq.io.deq
-  txm.io.div := div.U
-  txm.io.nstop := 0.U
-  io.uart.txd := txm.io.out
-  dontTouch(txm.io)
-
-  val beats = SERIAL_TSI_WIDTH / uartParams.dataBits
-
-  val rx_beats = RegInit(0.U(log2Ceil(beats).W))
-  val rx_last_beat = rx_beats === (beats-1).U
-  val rx_data = Reg(Vec(beats-1, UInt(uartParams.dataBits.W)))
-
-  val tx_beats = RegInit(0.U(log2Ceil(beats).W))
-  val tx_last_beat = tx_beats === (beats-1).U
-
-  rxq.io.deq.ready := Mux(rx_last_beat, io.serial.out.ready, true.B)
-  when (rxq.io.deq.fire()) {
-    rx_beats := Mux(rx_last_beat, 0.U, rx_beats + 1.U)
-    when (!rx_last_beat) { rx_data(rx_beats) := rxq.io.deq.bits }
+  io.narrow.in.ready := Mux(narrow_last_beat, io.wide.out.ready, true.B)
+  when (io.narrow.in.fire()) {
+    narrow_beats := Mux(narrow_last_beat, 0.U, narrow_beats + 1.U)
+    when (!narrow_last_beat) { narrow_data(narrow_beats) := io.narrow.in.bits }
   }
-  io.serial.out.valid := rx_last_beat && rxq.io.deq.valid
-  io.serial.out.bits := Cat(rxq.io.deq.bits, rx_data.asUInt)
+  io.wide.out.valid := narrow_last_beat && io.narrow.in.valid
+  io.wide.out.bits := Cat(io.narrow.in.bits, narrow_data.asUInt)
 
-  txq.io.enq.valid := io.serial.in.valid
-  txq.io.enq.bits := io.serial.in.bits >> (tx_beats << 3)
-  when (txq.io.enq.fire()) {
-    tx_beats := Mux(tx_last_beat, 0.U, tx_beats + 1.U)
+  io.narrow.out.valid := io.wide.in.valid
+  io.narrow.out.bits := io.wide.in.bits >> (wide_beats << 3)
+  when (io.narrow.out.fire()) {
+    wide_beats := Mux(wide_last_beat, 0.U, wide_beats + 1.U)
   }
-  io.serial.in.ready := tx_last_beat && txq.io.enq.ready
-
-  when (io.serial.out.fire()) {
-    printf("Serial out: %x\n", io.serial.out.bits);
-  }
-  when (io.serial.in.fire()) {
-    printf("Serial in: %x\n", io.serial.in.bits);
-  }
+  io.wide.in.ready := wide_last_beat && io.narrow.out.ready
 }

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -609,8 +609,7 @@ class MultiClockSerialAXIRAM(
 }
 
 
-class UARTToTSI(freq: BigInt) extends Module {
-  val uartParams = UARTParams(0)
+class UARTToTSI(freq: BigInt, uartParams: UARTParams) extends Module {
   val io = IO(new Bundle {
     val uart = new UARTPortIO(uartParams)
     val serial = new SerialIO(SERIAL_TSI_WIDTH)

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -619,10 +619,6 @@ class UARTToTSI(freq: BigInt) extends Module {
 
   val div = (freq / uartParams.initBaudRate).toInt
 
-  println(div)
-  println(freq)
-  println(uartParams.initBaudRate)
-
   rxm.io.en := true.B
   rxm.io.in := io.uart.rxd
   rxm.io.div := div.U

--- a/src/main/scala/UARTAdapter.scala
+++ b/src/main/scala/UARTAdapter.scala
@@ -29,94 +29,37 @@ class UARTAdapter(uartno: Int, div: Int) extends Module
     val uart = Flipped(new UARTPortIO(UARTParams(address = 0))) // We do not support the four wire variant
   })
 
-  val txfifo = Module(new Queue(UInt(DATA_WIDTH.W), 128))
-  val rxfifo = Module(new Queue(UInt(DATA_WIDTH.W), 128))
-
-  val uart_io = io.uart
-
-  val sTxIdle :: sTxWait :: sTxData :: sTxBreak :: Nil = Enum(4)
-  val txState = RegInit(sTxIdle)
-  val txData = Reg(UInt(DATA_WIDTH.W))
-  // iterate through bits in byte to deserialize
-  val (txDataIdx, txDataWrap) = Counter(txState === sTxData && txfifo.io.enq.ready, DATA_WIDTH)
-  // iterate using div to convert clock rate to baud
-  val (txBaudCount, txBaudWrap) = Counter(txState === sTxWait && txfifo.io.enq.ready, div)
-  val (txSlackCount, txSlackWrap) = Counter(txState === sTxIdle && uart_io.txd === 0.U && txfifo.io.enq.ready, 4)
-
-  switch(txState) {
-    is(sTxIdle) {
-      when(txSlackWrap) {
-        txData  := 0.U
-        txState := sTxWait
-      }
-    }
-    is(sTxWait) {
-      when(txBaudWrap) {
-        txState := sTxData
-      }
-    }
-    is(sTxData) {
-      when (txfifo.io.enq.ready) {
-        txData := txData | (uart_io.txd << txDataIdx)
-      }
-      when(txDataWrap) {
-        txState := Mux(uart_io.txd === 1.U, sTxIdle, sTxBreak)
-      }.elsewhen(txfifo.io.enq.ready) {
-        txState := sTxWait
-      }
-    }
-    is(sTxBreak) {
-      when(uart_io.txd === 1.U && txfifo.io.enq.ready) {
-        txState := sTxIdle
-      }
-    }
-  }
-
-  txfifo.io.enq.bits  := txData
-  txfifo.io.enq.valid := txDataWrap
-
-  val sRxIdle :: sRxStart :: sRxData :: Nil = Enum(3)
-  val rxState = RegInit(sRxIdle)
-  // iterate using div to convert clock rate to baud
-  val (rxBaudCount, rxBaudWrap) = Counter(txfifo.io.enq.ready, div)
-  // iterate through bits in byte to deserialize
-  val (rxDataIdx, rxDataWrap) = Counter(rxState === sRxData && txfifo.io.enq.ready && rxBaudWrap, DATA_WIDTH)
-
-  uart_io.rxd := 1.U
-  switch(rxState) {
-    is(sRxIdle) {
-      uart_io.rxd := 1.U
-      when (rxBaudWrap && rxfifo.io.deq.valid) {
-        rxState := sRxStart
-      }
-    }
-    is(sRxStart) {
-      uart_io.rxd := 0.U
-      when(rxBaudWrap) {
-        rxState := sRxData
-      }
-    }
-    is(sRxData) {
-      uart_io.rxd := (rxfifo.io.deq.bits >> rxDataIdx)(0)
-      when(rxDataWrap && rxBaudWrap) {
-        rxState := sRxIdle
-      }
-    }
-  }
-  rxfifo.io.deq.ready := (rxState === sRxData) && rxDataWrap && rxBaudWrap && txfifo.io.enq.ready
-
   val sim = Module(new SimUART(uartno))
+
+  val uartParams = UARTParams(0)
+  val txm = Module(new UARTRx(uartParams))
+  val txq = Module(new Queue(UInt(uartParams.dataBits.W), uartParams.nTxEntries))
+  val rxm = Module(new UARTTx(uartParams))
+  val rxq = Module(new Queue(UInt(uartParams.dataBits.W), uartParams.nRxEntries))
 
   sim.io.clock := clock
   sim.io.reset := reset.asBool
 
-  sim.io.serial.out.bits := txfifo.io.deq.bits
-  sim.io.serial.out.valid := txfifo.io.deq.valid
-  txfifo.io.deq.ready := sim.io.serial.out.ready
+  txm.io.en := true.B
+  txm.io.in := io.uart.txd
+  txm.io.div := div.U
+  txq.io.enq.valid := txm.io.out.valid
+  txq.io.enq.bits := txm.io.out.bits
+  when (txq.io.enq.valid) { assert(txq.io.enq.ready) }
 
-  rxfifo.io.enq.bits := sim.io.serial.in.bits
-  rxfifo.io.enq.valid := sim.io.serial.in.valid
-  sim.io.serial.in.ready := rxfifo.io.enq.ready && rxfifo.io.count < 127.U
+  rxm.io.en := true.B
+  rxm.io.in <> rxq.io.deq
+  rxm.io.div := div.U
+  rxm.io.nstop := 0.U
+  io.uart.rxd := rxm.io.out
+
+  sim.io.serial.out.bits := txq.io.deq.bits
+  sim.io.serial.out.valid := txq.io.deq.valid
+  txq.io.deq.ready := sim.io.serial.out.ready
+
+  rxq.io.enq.bits := sim.io.serial.in.bits
+  rxq.io.enq.valid := sim.io.serial.in.valid
+  sim.io.serial.in.ready := rxq.io.enq.ready && rxq.io.count < (uartParams.nRxEntries - 1).U
 }
 
 object UARTAdapter {

--- a/src/main/scala/UARTAdapter.scala
+++ b/src/main/scala/UARTAdapter.scala
@@ -98,3 +98,39 @@ class SimUART(uartno: Int) extends BlackBox(Map("UARTNO" -> IntParam(uartno))) w
   addResource("/testchipip/csrc/uart.cc")
   addResource("/testchipip/csrc/uart.h")
 }
+
+class UARTToSerial(freq: BigInt, uartParams: UARTParams) extends Module {
+  val io = IO(new Bundle {
+    val uart = new UARTPortIO(uartParams)
+    val serial = new SerialIO(8)
+    val dropped = Output(Bool()) // No flow control, so dropping a beat means we're screwed
+  })
+
+  val rxm = Module(new UARTRx(uartParams))
+  val rxq = Module(new Queue(UInt(uartParams.dataBits.W), uartParams.nRxEntries))
+  val txm = Module(new UARTTx(uartParams))
+  val txq = Module(new Queue(UInt(uartParams.dataBits.W), uartParams.nTxEntries))
+
+  val div = (freq / uartParams.initBaudRate).toInt
+
+  val dropped = RegInit(false.B)
+  io.dropped := dropped
+  rxm.io.en := true.B
+  rxm.io.in := io.uart.rxd
+  rxm.io.div := div.U
+  rxq.io.enq.valid := rxm.io.out.valid
+  rxq.io.enq.bits := rxm.io.out.bits
+  when (rxq.io.enq.valid) { assert(rxq.io.enq.ready) }
+  when (rxq.io.enq.valid && !rxq.io.enq.ready) { dropped := true.B } // no flow control
+  dontTouch(rxm.io)
+
+  txm.io.en := true.B
+  txm.io.in <> txq.io.deq
+  txm.io.div := div.U
+  txm.io.nstop := 0.U
+  io.uart.txd := txm.io.out
+  dontTouch(txm.io)
+
+  io.serial.out <> rxq.io.deq
+  txq.io.enq <> io.serial.in
+}

--- a/src/main/scala/UARTAdapter.scala
+++ b/src/main/scala/UARTAdapter.scala
@@ -1,4 +1,4 @@
-package sifive.blocks.devices.uart
+package testchipip
 
 import chisel3._
 import chisel3.util._

--- a/src/main/scala/UARTAdapter.scala
+++ b/src/main/scala/UARTAdapter.scala
@@ -116,7 +116,7 @@ class UARTAdapter(uartno: Int, div: Int) extends Module
 
   rxfifo.io.enq.bits := sim.io.serial.in.bits
   rxfifo.io.enq.valid := sim.io.serial.in.valid
-  sim.io.serial.in.ready := rxfifo.io.enq.ready
+  sim.io.serial.in.ready := rxfifo.io.enq.ready && rxfifo.io.count < 127.U
 }
 
 object UARTAdapter {

--- a/uart_tsi/Makefile
+++ b/uart_tsi/Makefile
@@ -2,4 +2,7 @@
 default: uart_tsi
 
 uart_tsi: testchip_uart_tsi.cc ../src/main/resources/testchipip/csrc/testchip_tsi.cc
-	g++ -L $(RISCV)/lib -I ../src/main/resources/testchipip/csrc -I $(RISCV)/include -std=c++17 -o $@ $^ -lfesvr -lpthread
+	g++ -O3 -L $(RISCV)/lib -I ../src/main/resources/testchipip/csrc -I $(RISCV)/include -std=c++17 -o $@ $^ -lfesvr -lpthread
+
+clean:
+	rm -rf uart_tsi

--- a/uart_tsi/Makefile
+++ b/uart_tsi/Makefile
@@ -1,0 +1,5 @@
+
+default: uart_tsi
+
+uart_tsi: testchip_uart_tsi.cc ../src/main/resources/testchipip/csrc/testchip_tsi.cc
+	g++ -L $(RISCV)/lib -I ../src/main/resources/testchipip/csrc -I $(RISCV)/include -std=c++17 -o $@ $^ -lfesvr -lpthread

--- a/uart_tsi/testchip_uart_tsi.cc
+++ b/uart_tsi/testchip_uart_tsi.cc
@@ -1,0 +1,112 @@
+#include "testchip_uart_tsi.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <termios.h>
+
+
+testchip_uart_tsi_t::testchip_uart_tsi_t(int argc, char** argv, char* ttyfile) : testchip_tsi_t(argc, argv, false) {
+  ttyfd = open(ttyfile, O_RDWR);
+  if (ttyfd < 0) {
+    printf("Error %i from open: %s\n", errno, strerror(errno));
+    exit(1);
+  }
+
+  // https://blog.mbedded.ninja/programming/operating-systems/linux/linux-serial-ports-using-c-cpp/
+  struct termios tty;
+
+  if (tcgetattr(ttyfd, &tty) != 0) {
+    printf("Error %i from tcgetaddr: %s\n", errno, strerror(errno));
+    exit(1);
+  }
+
+  tty.c_cflag &= ~PARENB; // Clear parity bit, disabling parity (most common)
+  tty.c_cflag &= ~CSTOPB; // Clear stop field, only one stop bit used in communication (most common)
+  tty.c_cflag |= CSTOPB;  // Set stop field, two stop bits used in communication
+  tty.c_cflag &= ~CSIZE;  // Clear all the size bits
+  tty.c_cflag &= CS8; // 8 bits per byte (most common)
+  tty.c_cflag &= ~CRTSCTS; // Disable RTS/CTS hardware flow control (most common)
+  tty.c_cflag |= CREAD | CLOCAL; // Turn on READ & ignore ctrl lines (CLOCAL = 1)
+
+  tty.c_lflag &= ~ICANON;
+  tty.c_lflag &= ~ECHO; // Disable echo
+  tty.c_lflag &= ~ECHOE; // Disable erasure
+  tty.c_lflag &= ~ECHONL; // Disable new-line echo
+  tty.c_lflag &= ~ISIG; // Disable interpretation of INTR, QUIT and SUSP
+
+  tty.c_iflag &= ~(IXON | IXOFF | IXANY); // Turn off s/w flow ctrl
+  tty.c_iflag &= ~(IGNBRK|BRKINT|PARMRK|ISTRIP|INLCR|IGNCR|ICRNL); // Disable any special handling of received bytes
+
+  tty.c_oflag &= ~OPOST; // Prevent special interpretation of output bytes (e.g. newline chars)
+  tty.c_oflag &= ~ONLCR; // Prevent conversion of newline to carriage return/line feed
+
+  tty.c_cc[VTIME] = 0;
+  tty.c_cc[VMIN] = 0;
+
+  // Set in/out baud rate to be B115200
+  cfsetispeed(&tty, B115200);
+  cfsetospeed(&tty, B115200);
+
+  // Save tty settings, also checking for error
+  if (tcsetattr(ttyfd, TCSANOW, &tty) != 0) {
+    printf("Error %i from tcsetattr: %s\n", errno, strerror(errno));
+  }
+};
+
+void testchip_uart_tsi_t::handle_uart() {
+  if (data_available()) {
+    uint32_t d = recv_word();
+    write(ttyfd, &d, sizeof(d));
+  }
+
+  uint8_t read_buf[256];
+  int n = read(ttyfd, &read_buf, sizeof(read_buf));
+  if (n < 0) {
+    printf("Error %i from read: %s\n", errno, strerror(errno));
+    exit(1);
+  }
+  for (int i = 0; i < n; i++) {
+    read_bytes.push_back(read_buf[i]);
+  }
+
+
+  if (read_bytes.size() >= 4) {
+    uint32_t out_data = 0;
+    uint8_t* b = ((uint8_t*)&out_data);
+    for (int i = 0; i < (sizeof(uint32_t) / sizeof(uint8_t)); i++) {
+      b[i] = read_bytes.front();
+      read_bytes.pop_front();
+    }
+    send_word(out_data);
+  }
+  //tick(out_valid, out_data, true);
+}
+
+int main(int argc, char* argv[]) {
+  printf("Starting UART-based TSI\n");
+  printf("Usage: ./uart_tsi +tty=/dev/pts/xx <PLUSARGS> bin\n");
+  printf("       ./uart_tsi +tty=/dev/ttyxx <PLUSARGS> bin\n");
+
+  char* tty = nullptr;
+  for (int i = 0; i < argc; i++) {
+    std::string arg(argv[i]);
+    if (arg.find("+tty=") == 0) {
+      tty = argv[i] + 5;
+    }
+  }
+  if (!tty) {
+    printf("ERROR: Must use +tty=/dev/ttyxx to specify a tty\n");
+    exit(1);
+  }
+  printf("Attempting to open TTY at %s\n", tty);
+  testchip_uart_tsi_t tsi(argc, argv, tty);
+  printf("Constructed uart_tsi_t\n");
+  while (!tsi.done()) {
+    tsi.switch_to_host();
+    tsi.handle_uart();
+  }
+  return tsi.exit_code();
+}

--- a/uart_tsi/testchip_uart_tsi.cc
+++ b/uart_tsi/testchip_uart_tsi.cc
@@ -228,7 +228,6 @@ int main(int argc, char* argv[]) {
   testchip_uart_tsi_t tsi(args.size(), tsi_argv,
 			  tty.data(), baud_rate,
 			  verbose, self_check);
-  printf("Constructed uart_tsi_t\n");
   printf("Checking connection status with %s\n", tty.c_str());
   if (!tsi.check_connection()) {
     printf("Connection failed\n");

--- a/uart_tsi/testchip_uart_tsi.h
+++ b/uart_tsi/testchip_uart_tsi.h
@@ -4,13 +4,17 @@
 class testchip_uart_tsi_t : public testchip_tsi_t
 {
 public:
-  testchip_uart_tsi_t(int argc, char** argv, char* tty);
+  testchip_uart_tsi_t(int argc, char** argv, char* tty, bool verbose);
   virtual ~testchip_uart_tsi_t() {};
 
   void handle_uart();
 
+  bool check_connection();
+
 private:
   int ttyfd;
   std::deque<uint8_t> read_bytes;
+  bool verbose;
+
 };
 #endif

--- a/uart_tsi/testchip_uart_tsi.h
+++ b/uart_tsi/testchip_uart_tsi.h
@@ -4,7 +4,9 @@
 class testchip_uart_tsi_t : public testchip_tsi_t
 {
 public:
-  testchip_uart_tsi_t(int argc, char** argv, char* tty, bool verbose, bool do_self_check);
+  testchip_uart_tsi_t(int argc, char** argv, char* tty,
+		      uint64_t baud_rate,
+		      bool verbose, bool do_self_check);
   virtual ~testchip_uart_tsi_t() {};
 
   bool handle_uart();

--- a/uart_tsi/testchip_uart_tsi.h
+++ b/uart_tsi/testchip_uart_tsi.h
@@ -4,17 +4,23 @@
 class testchip_uart_tsi_t : public testchip_tsi_t
 {
 public:
-  testchip_uart_tsi_t(int argc, char** argv, char* tty, bool verbose);
+  testchip_uart_tsi_t(int argc, char** argv, char* tty, bool verbose, bool do_self_check);
   virtual ~testchip_uart_tsi_t() {};
 
   bool handle_uart();
-
   bool check_connection();
+  void load_program() override;
+  void write_chunk(addr_t taddr, size_t nbytes, const void* src) override;
 
 private:
   int ttyfd;
   std::deque<uint8_t> read_bytes;
   bool verbose;
+  bool in_load_program;
+  bool do_self_check;
 
+  // Used for self-test
+  std::map<uint64_t, std::vector<uint8_t>> loaded_program;
 };
 #endif
+

--- a/uart_tsi/testchip_uart_tsi.h
+++ b/uart_tsi/testchip_uart_tsi.h
@@ -1,0 +1,16 @@
+#ifndef __TESTCHIP_UART_TSI_H
+#include "testchip_tsi.h"
+
+class testchip_uart_tsi_t : public testchip_tsi_t
+{
+public:
+  testchip_uart_tsi_t(int argc, char** argv, char* tty);
+  virtual ~testchip_uart_tsi_t() {};
+
+  void handle_uart();
+
+private:
+  int ttyfd;
+  std::deque<uint8_t> read_bytes;
+};
+#endif

--- a/uart_tsi/testchip_uart_tsi.h
+++ b/uart_tsi/testchip_uart_tsi.h
@@ -7,7 +7,7 @@ public:
   testchip_uart_tsi_t(int argc, char** argv, char* tty, bool verbose);
   virtual ~testchip_uart_tsi_t() {};
 
-  void handle_uart();
+  bool handle_uart();
 
   bool check_connection();
 


### PR DESCRIPTION
A PC host running the special `uart-tsi` fesvr implementation can communicate with a serial-adapter on a FPGA prototype or FPGA bringup-platform via UART.

Changes:
 - Allows forcing the SimUART DPI thing to put the UART on a pty
 - Fixes missing initialization of `is_loadmem` for testchip_tsi_t
 - Fixes bytes getting dropped out of the SimUART FIFO

Adds:
 - UART-to-TSI widget - intended for implementation on a FPGA board
 - `uart-tsi` FESVR implementation, tsi commands are sent out over a TTY
 
 Usage examples:
 
 Running a program
```
>  ./uart_tsi +tty=/dev/ttyUSB1 dhrystone.riscv
Attempting to open TTY at /dev/ttyUSB1
Constructed uart_tsi_t
Checking connection status with /dev/ttyUSB1
Connection succeeded
Microseconds for one run through Dhrystone: 452
Dhrystones per Second:                      2211
mcycle = 226186
minstret = 187526
Done, shutting down, flushing UART
```

Probing some register
```
> ./uart_tsi +tty=/dev/ttyUSB1 +init_read=0x10040 none
Attempting to open TTY at /dev/ttyUSB1
Constructed uart_tsi_t
Checking connection status with /dev/ttyUSB1
Connection succeeded
Reading 10040 ... got 517
```

Writing some register before running a program
```
> ./uart_tsi +tty=/dev/ttyUSB1 +init_write=0x88000000:0xdeadbeef test.riscv
Attempting to open TTY at /dev/ttyUSB1
Constructed uart_tsi_t
Checking connection status with /dev/ttyUSB1
Connection succeeded
Writing 88000000 with deadbeef
Done writing 88000000 with deadbeef
Hello world
Target reading from 0x88000000 - got deadbeef
Done, shutting down, flushing UART
```