### PR TITLE
Remove TLHelper

### DIFF
--- a/src/main/scala/BlockDevice.scala
+++ b/src/main/scala/BlockDevice.scala
@@ -105,8 +105,8 @@ class BlockDeviceArbiter(implicit p: Parameters) extends BlockDeviceModule {
 class BlockDeviceTracker(id: Int)(implicit p: Parameters)
     extends LazyModule with HasBlockDeviceParameters {
 
-  val node = TLHelper.makeClientNode(
-    name = s"blkdev-tracker$id", sourceId = IdRange(0, 1))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLClientParameters(
+    name = s"blkdev-tracker$id", sourceId = IdRange(0, 1))))))
 
   lazy val module = new BlockDeviceTrackerModule(this)
 }

--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -126,8 +126,8 @@ case object SerialAdapter {
 import SerialAdapter._
 
 class SerialAdapter(sourceIds: Int = 1)(implicit p: Parameters) extends LazyModule {
-  val node = TLHelper.makeClientNode(
-    name = "serial", sourceId = IdRange(0, sourceIds))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLClientParameters(
+    name = "serial", sourceId = IdRange(0, sourceIds))))))
 
   lazy val module = new SerialAdapterModule(this)
 }

--- a/src/main/scala/Unittests.scala
+++ b/src/main/scala/Unittests.scala
@@ -13,8 +13,8 @@ import scala.math.max
 
 class BlockDeviceTrackerTestDriver(nSectors: Int)(implicit p: Parameters)
     extends LazyModule with HasBlockDeviceParameters {
-  val node = TLHelper.makeClientNode(
-    name = "blkdev-testdriver", sourceId = IdRange(0, 1))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLClientParameters(
+    name = "blkdev-testdriver", sourceId = IdRange(0, 1))))))
 
   lazy val module = new Impl
   class Impl extends LazyModuleImp(this) {
@@ -286,7 +286,8 @@ class StreamWidthAdapterTest extends UnitTest {
 }
 
 class SwitcherDummy(implicit p: Parameters) extends LazyModule {
-  val node = TLHelper.makeClientNode("dummy", IdRange(0, 1))
+  val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLClientParameters(
+    "dummy", IdRange(0, 1))))))
 
   lazy val module = new LazyModuleImp(this) {
     val (tl, edge) = node.out(0)

--- a/src/main/scala/Util.scala
+++ b/src/main/scala/Util.scala
@@ -127,23 +127,6 @@ object WordSync {
   }
 }
 
-object TLHelper {
-  def makeClientNode(name: String, sourceId: IdRange)
-                    (implicit valName: ValName): TLClientNode =
-    makeClientNode(TLMasterParameters.v1(name, sourceId))
-
-  def makeClientNode(params: TLClientParameters)
-                    (implicit valName: ValName): TLClientNode =
-    TLClientNode(Seq(TLMasterPortParameters.v1(Seq(params))))
-
-  def makeManagerNode(beatBytes: Int, params: TLManagerParameters)
-                     (implicit valName: ValName): TLManagerNode =
-    TLManagerNode(Seq(TLSlavePortParameters.v1(Seq(params), beatBytes)))
-
-  def latency(lat: Int, node: TLOutwardNode)(implicit p: Parameters): TLOutwardNode =
-    TLBuffer.chain(lat).foldRight(node)(_ :=* _)
-}
-
 class DecoupledMux[T <: Data](typ: T, n: Int) extends Module {
   val io = IO(new Bundle {
     val in = Flipped(Vec(n, Decoupled(typ)))


### PR DESCRIPTION
People should just construct nodes explicitly.
Using TLHelper is a bad pattern, it obscures the actual implementation and provides minimal benefit. It also encourages dependencies on testchipip-as-a-package, which is burdensome to support.