### PR TITLE
fixes for xcelium

### DIFF
--- a/src/main/resources/testchipip/csrc/testchip_tsi.cc
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.cc
@@ -23,6 +23,9 @@ testchip_tsi_t::testchip_tsi_t(int argc, char** argv, bool can_have_loadmem) : t
     }
     if (arg.find("+no_hart0_msip") == 0)
       write_hart0_msip = false;
+    if (arg.find("+binary=") == 0) {
+      target_args().insert(target_args().begin(), arg.substr(8));
+    }
   }
 }
 

--- a/src/main/resources/testchipip/vsrc/SimUART.v
+++ b/src/main/resources/testchipip/vsrc/SimUART.v
@@ -16,7 +16,7 @@ import "DPI-C" function void uart_tick
     output byte    serial_in_bits
 );
 
-module SimUART #(UARTNO) (
+module SimUART #(UARTNO=0) (
     input              clock,
     input              reset,
 


### PR DESCRIPTION
* need defaults for verilog params (I only fixed the ones I tested in my design)
* need to pass binary using +binary= because sim tool will consume any args not prefixed with +/- and try to read them for its own purposes