### PR TITLE
Add SimTLMem

### DIFF
--- a/src/main/scala/SimTLMem.scala
+++ b/src/main/scala/SimTLMem.scala
@@ -1,6 +1,6 @@
 package testchipip
 
-import freechips.rocketchip.config.Parameters
+import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._
 

--- a/src/main/scala/SimTLMem.scala
+++ b/src/main/scala/SimTLMem.scala
@@ -1,0 +1,23 @@
+package testchipip
+
+import freechips.rocketchip.config.Parameters
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.tilelink._
+
+/** Memory with TL port for use in elaboratable test harnesses.
+ * 
+ * Topology: TLRAM <-< TLBuffer <-< TLXbar <-< TLMasterNode
+*/
+class SimTLMem(edge: TLEdgeParameters, size: BigInt, base: BigInt = 0)(implicit p: Parameters) extends SimpleLazyModule {
+  val node = TLClientNode(List(edge.master))
+  val srams = AddressSet.misaligned(base, size).map { aSet =>
+    LazyModule(new TLRAM(
+      address = aSet,
+      beatBytes = edge.bundle.dataBits/8))
+  }
+  val xbar = TLXbar()
+// srams.foreach{ s => s.node := TLBuffer() := TLFragmenter() := xbar }
+  srams.foreach{ s => s.node := TLBuffer() := xbar }
+  xbar := node
+  val io_tl = InModuleBody { node.makeIOs() }
+}

--- a/src/main/scala/SimTLMem.scala
+++ b/src/main/scala/SimTLMem.scala
@@ -16,7 +16,6 @@ class SimTLMem(edge: TLEdgeParameters, size: BigInt, base: BigInt = 0)(implicit 
       beatBytes = edge.bundle.dataBits/8))
   }
   val xbar = TLXbar()
-// srams.foreach{ s => s.node := TLBuffer() := TLFragmenter() := xbar }
   srams.foreach{ s => s.node := TLBuffer() := xbar }
   xbar := node
   val io_tl = InModuleBody { node.makeIOs() }


### PR DESCRIPTION
Add a SimTLMem which can be used in the simulation TestHarness when using a TL punch through