### PR TITLE
Flip serialized tilelink clock source

### DIFF
--- a/src/main/scala/SerialAdapter.scala
+++ b/src/main/scala/SerialAdapter.scala
@@ -297,6 +297,7 @@ case class SerialTLParams(
   romParams: SerialTLROMParams = SerialTLROMParams(),
   isMemoryDevice: Boolean = false,
   width: Int = 4,
+  provideClock: Boolean = false,
   axiMemOverSerialTLParams: Option[AXIMemOverSerialTLClockParams] = Some(AXIMemOverSerialTLClockParams()) // if enabled, expose axi port instead of TL RAM
 )
 case object SerialTLKey extends Field[Option[SerialTLParams]](None)
@@ -368,29 +369,42 @@ trait CanHavePeripheryTLSerial { this: BaseSubsystem =>
       )
     }
 
+    def serialType = if (params.provideClock) {
+      new ClockedIO(new SerialIO(params.width))
+    } else {
+      Flipped(new ClockedIO(Flipped(new SerialIO(params.width))))
+    }
+
     val inner_io = serial_tl_domain { InModuleBody {
-      val inner_io = IO(Flipped(new ClockedIO(Flipped(new SerialIO(params.width))))).suggestName("serial_tl")
+      val inner_io = IO(serialType).suggestName("serial_tl")
 
-      // Handle async crossing here, the off-chip clock should only drive part of the Async Queue
-      // The inner reset is the same as the serializer reset
-      // The outer reset is the inner reset sync'd to the outer clock
-      val outer_reset = ResetCatchAndSync(inner_io.clock, serdesser.module.reset.asBool)
-      val out_async = Module(new AsyncQueue(UInt(params.width.W)))
-      out_async.io.enq <> BlockDuringReset(serdesser.module.io.ser.out, 4)
-      out_async.io.enq_clock := serdesser.module.clock
-      out_async.io.enq_reset := serdesser.module.reset
-      out_async.io.deq_clock := inner_io.clock
-      out_async.io.deq_reset := outer_reset
+      if (params.provideClock) {
+        // no async crossing necessary, since the output pins are clocked with the serdesser
+        inner_io.clock := serdesser.module.clock
+        inner_io.bits.out <> BlockDuringReset(serdesser.module.io.ser.out, 4)
+        serdesser.module.io.ser.in <> BlockDuringReset(inner_io.bits.in, 4)
+      } else {
+        // Handle async crossing here, the off-chip clock should only drive part of the Async Queue
+        // The inner reset is the same as the serializer reset
+        // The outer reset is the inner reset sync'd to the outer clock
+        val outer_reset = ResetCatchAndSync(inner_io.clock, serdesser.module.reset.asBool)
+        val out_async = Module(new AsyncQueue(UInt(params.width.W)))
+        out_async.io.enq <> BlockDuringReset(serdesser.module.io.ser.out, 4)
+        out_async.io.enq_clock := serdesser.module.clock
+        out_async.io.enq_reset := serdesser.module.reset
+        out_async.io.deq_clock := inner_io.clock
+        out_async.io.deq_reset := outer_reset
 
-      val in_async = Module(new AsyncQueue(UInt(params.width.W)))
-      in_async.io.enq <> BlockDuringReset(inner_io.bits.in, 4)
-      in_async.io.enq_clock := inner_io.clock
-      in_async.io.enq_reset := outer_reset
-      in_async.io.deq_clock := serdesser.module.clock
-      in_async.io.deq_reset := serdesser.module.reset
+        val in_async = Module(new AsyncQueue(UInt(params.width.W)))
+        in_async.io.enq <> BlockDuringReset(inner_io.bits.in, 4)
+        in_async.io.enq_clock := inner_io.clock
+        in_async.io.enq_reset := outer_reset
+        in_async.io.deq_clock := serdesser.module.clock
+        in_async.io.deq_reset := serdesser.module.reset
 
-      inner_io.bits.out          <> out_async.io.deq
-      serdesser.module.io.ser.in <> in_async.io.deq
+        inner_io.bits.out          <> out_async.io.deq
+        serdesser.module.io.ser.in <> in_async.io.deq
+      }
       inner_io
     } }
     val outer_io = InModuleBody {


### PR DESCRIPTION
Generate the clock off-chip, instead of relying on the on-chip clock