### PR TITLE
fix(uart-tsi): use |= to set flag instead of &=

### DIFF
--- a/uart_tsi/testchip_uart_tsi.cc
+++ b/uart_tsi/testchip_uart_tsi.cc
@@ -61,9 +61,8 @@ testchip_uart_tsi_t::testchip_uart_tsi_t(int argc, char** argv,
 
   tty.c_cflag &= ~PARENB; // Clear parity bit, disabling parity (most common)
   tty.c_cflag &= ~CSTOPB; // Clear stop field, only one stop bit used in communication (most common)
-  tty.c_cflag |= CSTOPB;  // Set stop field, two stop bits used in communication
   tty.c_cflag &= ~CSIZE;  // Clear all the size bits
-  tty.c_cflag &= CS8; // 8 bits per byte (most common)
+  tty.c_cflag |= CS8; // 8 bits per byte (most common)
   tty.c_cflag &= ~CRTSCTS; // Disable RTS/CTS hardware flow control (most common)
   tty.c_cflag |= CREAD | CLOCAL; // Turn on READ & ignore ctrl lines (CLOCAL = 1)
 


### PR DESCRIPTION
Depending on some combination of {Kernel Version, UART Adapter}, the default value of the size field will get set to values other than 8 by default. The C code expects this and tries to manually set the `size = 8` flag, but does so by AND-ing the old flag with the new flag, which doesn't work because boolean logic.

Tested working on an [Terasic Apollo Agliex SOM](https://www.terasic.com.tw/cgi-bin/page/archive.pl?Language=English&No=1278) and verified via Signal Tap (logic analyzer).

