### PR TITLE
Fix Multi-UART | add ForcePTY

### DIFF
--- a/src/main/resources/testchipip/csrc/SimUART.cc
+++ b/src/main/resources/testchipip/csrc/SimUART.cc
@@ -10,9 +10,10 @@ uart_t *uart = NULL;
 
 extern "C" void uart_init(
         const char *filename,
-        int uartno)
+        int uartno,
+        int forcepty)
 {
-  bool use_pty = false;
+  bool use_pty = forcepty;
   s_vpi_vlog_info vinfo;
   if (!vpi_get_vlog_info(&vinfo))
     abort();

--- a/src/main/resources/testchipip/csrc/SimUART.cc
+++ b/src/main/resources/testchipip/csrc/SimUART.cc
@@ -3,10 +3,11 @@
 
 #include <stdio.h>
 #include <string.h>
+#include <map>
 
 #include "uart.h"
 
-uart_t *uart = NULL;
+std::map<int, uart_t*> uarts;
 
 extern "C" void uart_init(
         const char *filename,
@@ -21,35 +22,39 @@ extern "C" void uart_init(
     std::string arg(vinfo.argv[i]);
     if (arg == "+uart-pty")
       use_pty = true;
-    }
-
-    if (strlen(filename) != 0)
-      uart = new uart_t(filename, uartno, use_pty);
-    else
-      uart = new uart_t(0, uartno, use_pty);
+  }
+  if (uarts.find(uartno) != uarts.end()) {
+    printf("Attempting to initialize multiple uarts with same uartno=%d, aborting\n", uartno);
+    abort();
+  }
+  if (strlen(filename) != 0)
+    uarts[uartno] = new uart_t(filename, uartno, use_pty);
+  else
+    uarts[uartno] = new uart_t(0, uartno, use_pty);
 }
 
 extern "C" void uart_tick(
-        unsigned char out_valid,
-        unsigned char *out_ready,
-        char out_bits,
-
-        unsigned char *in_valid,
-        unsigned char in_ready,
-        char *in_bits)
+                          int uartno,
+                          unsigned char out_valid,
+                          unsigned char *out_ready,
+                          char out_bits,
+                          unsigned char *in_valid,
+                          unsigned char in_ready,
+                          char *in_bits)
 {
-    if (uart == NULL) {
-        *out_ready = 0;
-        *in_valid = 0;
-        return;
-    }
+  uart_t* uart = uarts[uartno];
+  if (uart == NULL) {
+    *out_ready = 0;
+    *in_valid = 0;
+    return;
+  }
 
-    uart->tick(
-        out_valid,
-        out_ready,
-        out_bits,
+  uart->tick(
+             out_valid,
+             out_ready,
+             out_bits,
 
-        in_valid,
-        in_ready,
-        in_bits);
+             in_valid,
+             in_ready,
+             in_bits);
 }

--- a/src/main/resources/testchipip/vsrc/SimUART.v
+++ b/src/main/resources/testchipip/vsrc/SimUART.v
@@ -1,8 +1,9 @@
 `define DATA_WIDTH 8
 
 import "DPI-C" function void uart_init(
-    input  string  filename,
-    input  int     uartno
+                                       input string filename,
+                                       input int    uartno,
+                                       input int    forcepty
 );
 
 import "DPI-C" function void uart_tick
@@ -16,7 +17,7 @@ import "DPI-C" function void uart_tick
     output byte    serial_in_bits
 );
 
-module SimUART #(UARTNO=0) (
+module SimUART #(UARTNO=0, FORCEPTY=0) (
     input              clock,
     input              reset,
 
@@ -42,7 +43,7 @@ module SimUART #(UARTNO=0) (
 
    initial begin
       $value$plusargs("uartlog=%s", __uartlog);
-      uart_init(__uartlog, __uartno);
+      uart_init(__uartlog, __uartno, FORCEPTY);
    end
 
    reg __in_valid_reg;

--- a/src/main/resources/testchipip/vsrc/SimUART.v
+++ b/src/main/resources/testchipip/vsrc/SimUART.v
@@ -8,13 +8,14 @@ import "DPI-C" function void uart_init(
 
 import "DPI-C" function void uart_tick
 (
-    input  bit     serial_out_valid,
-    output bit     serial_out_ready,
-    input  byte    serial_out_bits,
+ input int   uartno,
+ input bit   serial_out_valid,
+ output bit  serial_out_ready,
+ input byte  serial_out_bits,
 
-    output bit     serial_in_valid,
-    input  bit     serial_in_ready,
-    output byte    serial_in_bits
+ output bit  serial_in_valid,
+ input bit   serial_in_ready,
+ output byte serial_in_bits
 );
 
 module SimUART #(UARTNO=0, FORCEPTY=0) (
@@ -65,6 +66,7 @@ module SimUART #(UARTNO=0, FORCEPTY=0) (
          __uartno = UARTNO;
       end else begin
          uart_tick(
+                   __uartno,
                    __out_valid,
                    __out_ready,
                    __out_bits,
@@ -86,6 +88,5 @@ module SimUART #(UARTNO=0, FORCEPTY=0) (
    assign serial_out_ready = __out_ready_reg;
    assign __out_valid = serial_out_valid;
    assign __out_bits = serial_out_bits;
-
 
 endmodule

--- a/src/main/resources/testchipip/vsrc/SimUART.v
+++ b/src/main/resources/testchipip/vsrc/SimUART.v
@@ -40,11 +40,10 @@ module SimUART #(UARTNO=0, FORCEPTY=0) (
    wire [`DATA_WIDTH-1:0]    __out_bits;
 
    string                    __uartlog;
-   int                       __uartno;
 
    initial begin
       $value$plusargs("uartlog=%s", __uartlog);
-      uart_init(__uartlog, __uartno, FORCEPTY);
+      uart_init(__uartlog, UARTNO, FORCEPTY);
    end
 
    reg __in_valid_reg;
@@ -63,10 +62,9 @@ module SimUART #(UARTNO=0, FORCEPTY=0) (
          __in_valid_reg <= 0;
          __in_bits_reg <= 0;
          __out_ready_reg <= 0;
-         __uartno = UARTNO;
       end else begin
          uart_tick(
-                   __uartno,
+                   UARTNO,
                    __out_valid,
                    __out_ready,
                    __out_bits,


### PR DESCRIPTION
- Fixes multi-uart designs, now the multiple uarts are independent, while previously, they were all multiplexed off the same thing
- Allows forcePTY, which forces a SimUART to send the UART out to a pty

Note that this does not require a Chipyard bump, since APIs are unchanged. To avoid more churn in chipyard, I'll just open the PR here, and the next testchipip bump in chipyard will pick up these changes too.