### PR TITLE
Make BootAddrReg an optionally-enabled feature

### DIFF
--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -117,3 +117,19 @@ class WithTilesStartInReset(harts: Int*) extends Config((site, here, up) => {
 class WithNoSerialTL extends Config((site, here, up) => {
   case SerialTLKey => None
 })
+
+class WithBootAddrReg(params: BootAddrRegParams = BootAddrRegParams()) extends Config((site, here, up) => {
+  case BootAddrRegKey => Some(params)
+})
+
+class WithNoBootAddrReg extends Config((site, here, up) => {
+  case BootAddrRegKey => None
+})
+
+class WithCustomBootPin(params: CustomBootPinParams = CustomBootPinParams()) extends Config((site, here, up) => {
+  case CustomBootPinKey => Some(params)
+})
+
+class WithNoCustomBootPin extends Config((site, here, up) => {
+  case CustomBootPinKey => None
+})

--- a/src/main/scala/CustomBootPin.scala
+++ b/src/main/scala/CustomBootPin.scala
@@ -26,6 +26,7 @@ class WithCustomBootPinAltAddr(address: BigInt) extends Config((site, here, up) 
 
 trait CanHavePeripheryCustomBootPin { this: BaseSubsystem =>
   val custom_boot_pin = p(CustomBootPinKey).map { params =>
+    require(p(BootAddrRegKey).isDefined, "CustomBootPin relies on existence of BootAddrReg")
     val tlbus = locateTLBusWrapper(params.masterWhere)
     val clientParams = TLMasterPortParameters.v1(
       clients = Seq(TLMasterParameters.v1(
@@ -52,7 +53,7 @@ trait CanHavePeripheryCustomBootPin { this: BaseSubsystem =>
           is (waiting_bootaddr_reg_a) {
             tl.a.valid := true.B
             tl.a.bits := edge.Put(
-              toAddress = p(BootAddrRegKey).bootRegAddress.U,
+              toAddress = p(BootAddrRegKey).get.bootRegAddress.U,
               fromSource = 0.U,
               lgSize = 2.U,
               data = params.customBootAddress.U


### PR DESCRIPTION
Previously, BootAddrReg was always present on all designs.
It doesn't make since to add this to designs with no cores, so make this an optional device intsead.