### PR TITLE
Tracedoctor

### DIFF
--- a/src/main/scala/TraceDoctor.scala
+++ b/src/main/scala/TraceDoctor.scala
@@ -1,0 +1,66 @@
+package testchipip
+
+import chipsalliance.rocketchip.config.Field
+import chisel3._
+import freechips.rocketchip.diplomacy.{BundleBridgeNexusNode, LazyModuleImp}
+import freechips.rocketchip.rocket.TraceDoctor
+import freechips.rocketchip.subsystem.HasTiles
+import freechips.rocketchip.util.HeterogeneousBag
+
+
+// A per-tile interface that includes the tile's clock and reset
+class TileTraceDoctorIO(val traceWidth: Int) extends Bundle {
+  val clock: Clock = Clock()
+  val reset: Bool = Bool()
+  val data = new TraceDoctor(traceWidth)
+}
+
+// The IO matched on by the TraceDoctor bridge: a wrapper around a heterogenous
+// bag of TileTraceDoctorIO. Each entry is trace associated with a single tile
+class TraceDoctorOutputTop(val traceWidths: Seq[Int]) extends Bundle {
+  val tracedoctors: HeterogeneousBag[TileTraceDoctorIO] = Output(HeterogeneousBag(traceWidths.map(w => new TileTraceDoctorIO(w))))
+}
+
+object TraceDoctorOutputTop {
+  def apply(proto: Seq[TraceDoctor]): TraceDoctorOutputTop =
+    new TraceDoctorOutputTop(proto.map(t => t.traceWidth))
+}
+
+// Use this trait:
+trait CanHaveTraceDoctorIO { this: HasTiles =>
+  val module: CanHaveTraceDoctorIOModuleImp
+  // Bind all the trace nodes to a BB; we'll use this to generate the IO in the imp
+  val traceDoctorNexus = BundleBridgeNexusNode[TraceDoctor]()
+  tiles.foreach { traceDoctorNexus := _.traceDoctorNode }
+}
+case class TraceDoctorPortParams(print: Boolean = false)
+object TraceDoctorPortKey extends Field[Option[TraceDoctorPortParams]](None)
+
+trait CanHaveTraceDoctorIOModuleImp extends LazyModuleImp {
+  val outer: CanHaveTraceDoctorIO with HasTiles
+
+  val traceDoctorIO = p(TraceDoctorPortKey) map ( traceParams => {
+    val traceDoctorSeq = (outer.traceDoctorNexus.in.map(_._1))
+    val tio = IO(Output(TraceDoctorOutputTop(traceDoctorSeq)))
+
+    (tio.tracedoctors zip (outer.tile_prci_domains zip traceDoctorSeq)).foreach { case (port, (prci, tracedoc)) =>
+      port.clock := prci.module.clock
+      port.reset := prci.module.reset.asBool
+      port.data := tracedoc
+    }
+
+    if (traceParams.print) {
+      for ((trace, idx) <- tio.tracedoctors.zipWithIndex ) {
+        withClockAndReset(trace.clock, trace.reset) {
+          when (trace.data.valid) {
+            printf(s"TraceDoctor $idx: %x\n", trace.data.bits.asUInt)
+          }
+        }
+      }
+    }
+    tio
+  })
+}
+
+
+

--- a/src/main/scala/TraceDoctor.scala
+++ b/src/main/scala/TraceDoctor.scala
@@ -13,6 +13,7 @@ class TileTraceDoctorIO(val traceWidth: Int) extends Bundle {
   val clock: Clock = Clock()
   val reset: Bool = Bool()
   val data = new TraceDoctor(traceWidth)
+  val tracerVTrigger: Bool = Bool()
 }
 
 // The IO matched on by the TraceDoctor bridge: a wrapper around a heterogenous
@@ -47,6 +48,11 @@ trait CanHaveTraceDoctorIOModuleImp extends LazyModuleImp {
       port.clock := prci.module.clock
       port.reset := prci.module.reset.asBool
       port.data := tracedoc
+
+      port.tracerVTrigger := false.B
+      midas.targetutils.TriggerSink.whenEnabled(false.B) {
+        port.tracerVTrigger := true.B
+      }
     }
 
     if (traceParams.print) {


### PR DESCRIPTION
TraceDoctor support in Firesim.

These changes provide necessary TraceDoctorIO classes similar to TracerV. TraceDoctor also attaches here to the TracerV trigger system.