### PR TITLE
Fix DRAMSim2 sign extension bug

### DIFF
--- a/src/main/resources/testchipip/csrc/SimDRAM.cc
+++ b/src/main/resources/testchipip/csrc/SimDRAM.cc
@@ -77,11 +77,13 @@ extern "C" void *memory_init(
     }
 
     if (use_dramsim)
-      mm = (mm_t *) (new mm_dramsim2_t(mem_size, word_size, line_size, backing_mem_data[mem_base],
+      mm = (mm_t *) (new mm_dramsim2_t(mem_base, mem_size, word_size, line_size,
+                                       backing_mem_data[mem_base],
                                        memory_ini, system_ini, ini_dir,
                                        1 << id_bits, clock_hz));
     else
-      mm = (mm_t *) (new mm_magic_t(mem_size, word_size, line_size, backing_mem_data[mem_base]));
+      mm = (mm_t *) (new mm_magic_t(mem_base, mem_size, word_size, line_size,
+                                    backing_mem_data[mem_base]));
 
 
     return mm;
@@ -94,14 +96,14 @@ extern "C" void memory_tick(
 
         unsigned char ar_valid,
         unsigned char *ar_ready,
-        int ar_addr,
+        long long int ar_addr,
         int ar_id,
         int ar_size,
         int ar_len,
 
         unsigned char aw_valid,
         unsigned char *aw_ready,
-        int aw_addr,
+        long long int aw_addr,
         int aw_id,
         int aw_size,
         int aw_len,

--- a/src/main/resources/testchipip/csrc/mm.h
+++ b/src/main/resources/testchipip/csrc/mm.h
@@ -18,8 +18,8 @@ struct backing_data_t
 class mm_t
 {
  public:
-  mm_t(size_t mem_sz, size_t word_sz, size_t line_sz, backing_data_t& dat) :
-    data(dat.data), size(mem_sz), word_size(word_sz), line_size(line_sz) {
+  mm_t(size_t mem_bs, size_t mem_sz, size_t word_sz, size_t line_sz, backing_data_t& dat) :
+    data(dat.data), mem_base(mem_bs), mem_size(mem_sz), word_size(word_sz), line_size(line_sz) {
     assert(dat.size == mem_sz);
   }
 
@@ -61,7 +61,8 @@ class mm_t
   ) = 0;
 
   virtual void* get_data() { return data; }
-  virtual size_t get_size() { return size; }
+  virtual size_t get_size() { return mem_size; }
+  virtual size_t get_base() { return mem_base; }
   virtual size_t get_word_size() { return word_size; }
   virtual size_t get_line_size() { return line_size; }
 
@@ -72,7 +73,8 @@ class mm_t
   uint8_t* data;
 
  protected:
-  size_t size;
+  size_t mem_base;
+  size_t mem_size;
   int word_size;
   int line_size;
 };
@@ -100,8 +102,8 @@ struct mm_rresp_t
 class mm_magic_t : public mm_t
 {
  public:
-  mm_magic_t(size_t mem_sz, size_t word_sz, size_t line_sz, backing_data_t& dat) :
-    mm_t(mem_sz, word_sz, line_sz, dat), store_inflight(false) {}
+  mm_magic_t(size_t mem_base, size_t mem_sz, size_t word_sz, size_t line_sz, backing_data_t& dat) :
+    mm_t(mem_base, mem_sz, word_sz, line_sz, dat), store_inflight(false) {}
 
   virtual bool ar_ready() { return true; }
   virtual bool aw_ready() { return !store_inflight; }

--- a/src/main/resources/testchipip/csrc/mm_dramsim2.cc
+++ b/src/main/resources/testchipip/csrc/mm_dramsim2.cc
@@ -42,14 +42,14 @@ void power_callback(double a, double b, double c, double d)
 }
 
 
-mm_dramsim2_t::mm_dramsim2_t(size_t mem_sz, size_t word_sz, size_t line_sz, backing_data_t& dat, std::string memory_ini, std::string system_ini, std::string ini_dir, int axi4_ids, size_t clock_hz) :
-  mm_t(mem_sz, word_sz, line_sz, dat),
+mm_dramsim2_t::mm_dramsim2_t(size_t mem_base, size_t mem_sz, size_t word_sz, size_t line_sz, backing_data_t& dat, std::string memory_ini, std::string system_ini, std::string ini_dir, int axi4_ids, size_t clock_hz) :
+  mm_t(mem_base, mem_sz, word_sz, line_sz, dat),
   read_id_busy(axi4_ids, false),
   write_id_busy(axi4_ids, false) {
 
   assert(line_sz == 64); // assumed by dramsim2
   assert(mem_sz % (1024*1024) == 0);
-  mem = getMemorySystemInstance(memory_ini, system_ini, ini_dir, "results", size/(1024*1024));
+  mem = getMemorySystemInstance(memory_ini, system_ini, ini_dir, "results", mem_size/(1024*1024));
   mem->setCPUClockSpeed(clock_hz);
   TransactionCompleteCB *read_cb = new Callback<mm_dramsim2_t, void, unsigned, uint64_t, uint64_t>(this, &mm_dramsim2_t::read_complete);
   TransactionCompleteCB *write_cb = new Callback<mm_dramsim2_t, void, unsigned, uint64_t, uint64_t>(this, &mm_dramsim2_t::write_complete);

--- a/src/main/resources/testchipip/csrc/mm_dramsim2.h
+++ b/src/main/resources/testchipip/csrc/mm_dramsim2.h
@@ -36,7 +36,7 @@ struct mm_req_t {
 class mm_dramsim2_t : public mm_t
 {
  public:
-  mm_dramsim2_t(size_t mem_sz, size_t word_sz, size_t line_sz, backing_data_t& dat, std::string memory_ini, std::string system_ini, std::string ini_dir, int axi4_ids, size_t clock_hz);
+  mm_dramsim2_t(size_t mem_base, size_t mem_sz, size_t word_sz, size_t line_sz, backing_data_t& dat, std::string memory_ini, std::string system_ini, std::string ini_dir, int axi4_ids, size_t clock_hz);
 
   virtual bool ar_ready();
   virtual bool aw_ready();

--- a/src/main/resources/testchipip/vsrc/SimDRAM.v
+++ b/src/main/resources/testchipip/vsrc/SimDRAM.v
@@ -10,39 +10,39 @@ import "DPI-C" function chandle memory_init
 
 import "DPI-C" function void memory_tick
 (
-  input  chandle channel,
+  input chandle  channel,
 
-  input  bit     reset,
+  input bit      reset,
 
-  input  bit     ar_valid,
+  input bit      ar_valid,
   output bit     ar_ready,
-  input  int     ar_addr,
-  input  int     ar_id,
-  input  int     ar_size,
-  input  int     ar_len,
+  input longint  ar_addr,
+  input int      ar_id,
+  input int      ar_size,
+  input int      ar_len,
 
-  input  bit     aw_valid,
+  input bit      aw_valid,
   output bit     aw_ready,
-  input  int     aw_addr,
-  input  int     aw_id,
-  input  int     aw_size,
-  input  int     aw_len,
+  input longint  aw_addr,
+  input int      aw_id,
+  input int      aw_size,
+  input int      aw_len,
 
-  input  bit     w_valid,
+  input bit      w_valid,
   output bit     w_ready,
-  input  int     w_strb,
-  input  longint w_data,
-  input  bit     w_last,
+  input int      w_strb,
+  input longint  w_data,
+  input bit      w_last,
 
   output bit     r_valid,
-  input  bit     r_ready,
+  input bit      r_ready,
   output int     r_id,
   output int     r_resp,
   output longint r_data,
   output bit     r_last,
 
   output bit     b_valid,
-  input  bit     b_ready,
+  input bit      b_ready,
   output int     b_id,
   output int     b_resp
 );
@@ -100,13 +100,13 @@ module SimDRAM #(
   chandle channel;
 
   wire __ar_valid;
-  wire [31:0] __ar_addr;
+  wire [63:0] __ar_addr;
   wire [31:0] __ar_id;
   wire [31:0] __ar_size;
   wire [31:0] __ar_len;
 
   wire __aw_valid;
-  wire [31:0] __aw_addr;
+  wire [63:0] __aw_addr;
   wire [31:0] __aw_id;
   wire [31:0] __aw_size;
   wire [31:0] __aw_len;


### PR DESCRIPTION
The old coder used `addr % size` to subtract out the DRAM base offset, but this doesn't work when DRAM is not aligned to the size.

Overall this makes `mm_t` more robust.