### PR TITLE
Dromajo saturn

### DIFF
--- a/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
+++ b/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
@@ -78,7 +78,8 @@ extern "C" int dromajo_step(
     bool     check,
     bool     wdata_valid,
     int      wdata_dest,
-    int      insn_writes_back)
+    bool     insn_writes_back,
+    int      insn_wdata_dest)
 {
     // need a reorder buffer
     // keep instruction until wdata is valid
@@ -88,8 +89,9 @@ extern "C" int dromajo_step(
     printf("I GOT THE WDATA_VALID %d\n", wdata_valid);
     printf("I GOT THE WDATA_DEST %d\n", wdata_dest);
     printf("I GOT THE WDATA %d\n", dut_wdata);
-    printf("I GOT THE INSN WRITS BACK %d\n", insn_writes_back);
-    printf("\n");
+    printf("I GOT THE INSN WRITES BACK %d\n", insn_writes_back);
+    printf("I GOT THE INSN WDATA DEST %d\n", insn_wdata_dest);
+    printf("checking\n");
     return dromajo->step(hartid, dut_pc, dut_insn, dut_wdata, mstatus, check);
 }
 

--- a/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
+++ b/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
@@ -69,6 +69,30 @@ extern "C" int dromajo_init(
     return 0;
 }
 
+// void showlist(list<instrElem> g)
+// {
+//     list<instrElem>::iterator it;
+//     for (it = g.begin(); it != g.end(); ++it) {
+//         printf("INSN %d\n", it.dut_insn);
+//         // printf("I GOT THE WDATA_DEST %d\n", wdata_dest);
+//         // printf("I GOT THE WDATA %x\n", dut_wdata);
+//         // printf("I GOT THE INSN WRITES BACK %d\n", insn_writes_back);
+//         // printf("I GOT THE INSN WDATA DEST %d\n", insn_wdata_dest)
+//     }
+// }
+
+struct instrElem {
+  bool      wdata_valid;
+  int       wdata_dest;
+
+  int      hartid;
+  long long dut_pc;
+  int dut_insn;
+  long long dut_wdata;
+  long long mstatus;
+  bool     check;
+};
+
 extern "C" int dromajo_step(
     int      hartid,
     long long dut_pc,
@@ -88,10 +112,23 @@ extern "C" int dromajo_step(
     // then pop off as many instructions as u can & call dromajo step
     printf("I GOT THE WDATA_VALID %d\n", wdata_valid);
     printf("I GOT THE WDATA_DEST %d\n", wdata_dest);
-    printf("I GOT THE WDATA %d\n", dut_wdata);
+    printf("I GOT THE WDATA %x\n", dut_wdata);
     printf("I GOT THE INSN WRITES BACK %d\n", insn_writes_back);
     printf("I GOT THE INSN WDATA DEST %d\n", insn_wdata_dest);
-    printf("checking\n");
+    printf("check\n");
+    //list<instrElem> instruction_queue;
+    instrElem instruction_element;
+    instruction_element.wdata_valid = 0;
+    instruction_element.wdata_dest = insn_wdata_dest;
+    instruction_element.hartid = hartid;
+    instruction_element.dut_pc = dut_pc;
+    instruction_element.dut_insn = dut_insn;
+    instruction_element.dut_wdata = dut_wdata;
+    instruction_element.mstatus = mstatus;
+    instruction_element.check = check;
+
+    //instruction_queue.push_back(instruction_element);
+    // showlist(instruction_queue);
     return dromajo->step(hartid, dut_pc, dut_insn, dut_wdata, mstatus, check);
 }
 

--- a/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
+++ b/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
@@ -77,7 +77,8 @@ extern "C" int dromajo_step(
     long long mstatus,
     bool     check,
     bool     wdata_valid,
-    int      wdata_dest)
+    int      wdata_dest,
+    int      insn_writes_back)
 {
     // need a reorder buffer
     // keep instruction until wdata is valid
@@ -87,7 +88,7 @@ extern "C" int dromajo_step(
     printf("I GOT THE WDATA_VALID %d\n", wdata_valid);
     printf("I GOT THE WDATA_DEST %d\n", wdata_dest);
     printf("I GOT THE WDATA %d\n", dut_wdata);
-    //printf("I GOT THE INSN WRITS BACK %d\n", insn_writes_back);
+    printf("I GOT THE INSN WRITS BACK %d\n", insn_writes_back);
     printf("\n");
     return dromajo->step(hartid, dut_pc, dut_insn, dut_wdata, mstatus, check);
 }

--- a/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
+++ b/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
@@ -111,13 +111,16 @@ extern "C" int dromajo_step(
     // valid instruction --> into queue
     // wdata --> scan list of isntructions until find same register, add info, amrk that isntructions is ready to pop off
     // then pop off as many instructions as u can & call dromajo step
+    printf("wdata stuff:\n");
     printf("I GOT THE WDATA_VALID %d\n", wdata_valid);
     printf("I GOT THE WDATA_DEST %d\n", wdata_dest);
     printf("I GOT THE WDATA %x\n", dut_wdata);
+    printf("instr stuff:\n");
+    printf("INSN PC %lx\n", dut_pc);
     printf("I GOT THE INSN VALID %d\n", valid);
     printf("I GOT THE INSN WRITES BACK %d\n", insn_writes_back);
     printf("I GOT THE INSN WDATA DEST %d\n", insn_wdata_dest);
-    printf("check\n");
+    printf("checkkkkkk\n");
     //list<instrElem> instruction_queue;
     instrElem instruction_element;
     instruction_element.wdata_valid = 0;
@@ -131,7 +134,12 @@ extern "C" int dromajo_step(
 
     //instruction_queue.push_back(instruction_element);
     // showlist(instruction_queue);
-    return dromajo->step(hartid, dut_pc, dut_insn, dut_wdata, mstatus, check);
+    if (valid) {
+        return dromajo->step(hartid, dut_pc, dut_insn, dut_wdata, mstatus, check);
+    } else {
+        printf("it not valid!!");
+    }
+    
 }
 
 extern "C" void dromajo_raise_trap(

--- a/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
+++ b/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
@@ -75,8 +75,20 @@ extern "C" int dromajo_step(
     int dut_insn,
     long long dut_wdata,
     long long mstatus,
-    bool     check)
+    bool     check,
+    bool     wdata_valid,
+    int      wdata_dest)
 {
+    // need a reorder buffer
+    // keep instruction until wdata is valid
+    // valid instruction --> into queue
+    // wdata --> scan list of isntructions until find same register, add info, amrk that isntructions is ready to pop off
+    // then pop off as many instructions as u can & call dromajo step
+    printf("I GOT THE WDATA_VALID %d\n", wdata_valid);
+    printf("I GOT THE WDATA_DEST %d\n", wdata_dest);
+    printf("I GOT THE WDATA %d\n", dut_wdata);
+    //printf("I GOT THE INSN WRITS BACK %d\n", insn_writes_back);
+    printf("\n");
     return dromajo->step(hartid, dut_pc, dut_insn, dut_wdata, mstatus, check);
 }
 

--- a/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
+++ b/src/main/resources/testchipip/csrc/SimDromajoCosim.cc
@@ -94,6 +94,7 @@ struct instrElem {
 };
 
 extern "C" int dromajo_step(
+    bool     valid,
     int      hartid,
     long long dut_pc,
     int dut_insn,
@@ -113,6 +114,7 @@ extern "C" int dromajo_step(
     printf("I GOT THE WDATA_VALID %d\n", wdata_valid);
     printf("I GOT THE WDATA_DEST %d\n", wdata_dest);
     printf("I GOT THE WDATA %x\n", dut_wdata);
+    printf("I GOT THE INSN VALID %d\n", valid);
     printf("I GOT THE INSN WRITES BACK %d\n", insn_writes_back);
     printf("I GOT THE INSN WDATA DEST %d\n", insn_wdata_dest);
     printf("check\n");

--- a/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
+++ b/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
@@ -71,23 +71,23 @@ module SimDromajoCosimBlackBox
     always @(posedge clock) begin
         if (!reset) begin
             for (__itr=0; __itr<COMMIT_WIDTH; __itr=__itr+1) begin
-                if (valid[__itr]) begin
-                    __fail = dromajo_step(
-                        valid[__itr],
-                        hartid,
-                        pc[((__itr+1)*XLEN - 1)-:XLEN],
-                        inst[((__itr+1)*INST_BITS - 1)-:INST_BITS],
-                        wdata[((__itr+1)*XLEN - 1)-:XLEN],
-                        mstatus[((__itr+1)*XLEN - 1)-:XLEN],
-                        check[__itr],
-                        wdata_valid[__itr],
-                        wdata_dest[((__itr+1)*RD - 1)-:RD],
-                        insn_writes_back[__itr],
-                        insn_wdata_dest[((__itr+1)*RD - 1)-:RD]);
-                    if (__fail != 0) begin
-                        $display("FAIL: Dromajo Simulation Failed with exit code: %d", __fail);
-                        $fatal;
-                    end
+                // if (valid[__itr]) begin
+                __fail = dromajo_step(
+                    valid[__itr],
+                    hartid,
+                    pc[((__itr+1)*XLEN - 1)-:XLEN],
+                    inst[((__itr+1)*INST_BITS - 1)-:INST_BITS],
+                    wdata[((__itr+1)*XLEN - 1)-:XLEN],
+                    mstatus[((__itr+1)*XLEN - 1)-:XLEN],
+                    check[__itr],
+                    wdata_valid[__itr],
+                    wdata_dest[((__itr+1)*RD - 1)-:RD],
+                    insn_writes_back[__itr],
+                    insn_wdata_dest[((__itr+1)*RD - 1)-:RD]);
+                if (__fail != 0) begin
+                    $display("FAIL: Dromajo Simulation Failed with exit code: %d", __fail);
+                    $fatal;
+                    // end
                 end
             end
 

--- a/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
+++ b/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
@@ -13,7 +13,8 @@ import "DPI-C" function int dromajo_step(
     input bit     check,
     input bit     wdata_valid,
     input int     wdata_dest,
-    input bit     insn_writes_back);
+    input bit     insn_writes_back,
+    input int     insn_wdata_dest);
 
 import "DPI-C" function void dromajo_raise_trap(
     input int     hartid,
@@ -37,8 +38,8 @@ module SimDromajoCosimBlackBox
     input [          (COMMIT_WIDTH) - 1:0] wdata_valid,
     input [       (RD*COMMIT_WIDTH) - 1:0] wdata_dest,
     input [          (COMMIT_WIDTH) - 1:0] insn_writes_back,
-//insn_writes_back
-//insn_wdata_dest
+    input [       (RD*COMMIT_WIDTH) - 1:0] insn_wdata_dest,
+
     input           int_xcpt,
     input [XLEN - 1:0] cause
 );
@@ -79,7 +80,8 @@ module SimDromajoCosimBlackBox
                         check[__itr],
                         wdata_valid[__itr],
                         wdata_dest[((__itr+1)*RD - 1)-:RD],
-                        insn_writes_back[__itr]);
+                        insn_writes_back[__itr],
+                        insn_wdata_dest[((__itr+1)*RD - 1)-:RD]);
                     if (__fail != 0) begin
                         $display("FAIL: Dromajo Simulation Failed with exit code: %d", __fail);
                         $fatal;

--- a/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
+++ b/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
@@ -12,7 +12,8 @@ import "DPI-C" function int dromajo_step(
     input longint mstatus,
     input bit     check,
     input bit     wdata_valid,
-    input int     wdata_dest);
+    input int     wdata_dest,
+    input bit     insn_writes_back);
 
 import "DPI-C" function void dromajo_raise_trap(
     input int     hartid,
@@ -35,6 +36,7 @@ module SimDromajoCosimBlackBox
 
     input [          (COMMIT_WIDTH) - 1:0] wdata_valid,
     input [       (RD*COMMIT_WIDTH) - 1:0] wdata_dest,
+    input [          (COMMIT_WIDTH) - 1:0] insn_writes_back,
 //insn_writes_back
 //insn_wdata_dest
     input           int_xcpt,
@@ -76,7 +78,8 @@ module SimDromajoCosimBlackBox
                         mstatus[((__itr+1)*XLEN - 1)-:XLEN],
                         check[__itr],
                         wdata_valid[__itr],
-                        wdata_dest[((__itr+1)*RD - 1)-:RD]);
+                        wdata_dest[((__itr+1)*RD - 1)-:RD],
+                        insn_writes_back[__itr]);
                     if (__fail != 0) begin
                         $display("FAIL: Dromajo Simulation Failed with exit code: %d", __fail);
                         $fatal;

--- a/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
+++ b/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
@@ -5,6 +5,7 @@ import "DPI-C" function int dromajo_init(
 );
 
 import "DPI-C" function int dromajo_step(
+    input bit     valid,
     input int     hartid,
     input longint dut_pc,
     input int     dut_insn,
@@ -28,7 +29,7 @@ module SimDromajoCosimBlackBox
     input reset,
 
     input [          (COMMIT_WIDTH) - 1:0] valid  ,
-    input [           (HARTID_LEN) - 1:0] hartid ,
+    input [            (HARTID_LEN) - 1:0] hartid ,
     input [     (XLEN*COMMIT_WIDTH) - 1:0] pc     ,
     input [(INST_BITS*COMMIT_WIDTH) - 1:0] inst   ,
     input [     (XLEN*COMMIT_WIDTH) - 1:0] wdata  ,
@@ -72,6 +73,7 @@ module SimDromajoCosimBlackBox
             for (__itr=0; __itr<COMMIT_WIDTH; __itr=__itr+1) begin
                 if (valid[__itr]) begin
                     __fail = dromajo_step(
+                        valid[__itr],
                         hartid,
                         pc[((__itr+1)*XLEN - 1)-:XLEN],
                         inst[((__itr+1)*INST_BITS - 1)-:INST_BITS],

--- a/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
+++ b/src/main/resources/testchipip/vsrc/SimDromajoCosimBlackBox.v
@@ -10,8 +10,9 @@ import "DPI-C" function int dromajo_step(
     input int     dut_insn,
     input longint dut_wdata,
     input longint mstatus,
-    input bit     check
-);
+    input bit     check,
+    input bit     wdata_valid,
+    input int     wdata_dest);
 
 import "DPI-C" function void dromajo_raise_trap(
     input int     hartid,
@@ -19,7 +20,7 @@ import "DPI-C" function void dromajo_raise_trap(
 );
 
 module SimDromajoCosimBlackBox
-    #(parameter COMMIT_WIDTH, XLEN, INST_BITS, HARTID_LEN)
+    #(parameter COMMIT_WIDTH, RD, XLEN, INST_BITS, HARTID_LEN)
 (
     input clock,
     input reset,
@@ -32,6 +33,10 @@ module SimDromajoCosimBlackBox
     input [     (XLEN*COMMIT_WIDTH) - 1:0] mstatus,
     input [          (COMMIT_WIDTH) - 1:0] check  ,
 
+    input [          (COMMIT_WIDTH) - 1:0] wdata_valid,
+    input [       (RD*COMMIT_WIDTH) - 1:0] wdata_dest,
+//insn_writes_back
+//insn_wdata_dest
     input           int_xcpt,
     input [XLEN - 1:0] cause
 );
@@ -69,7 +74,9 @@ module SimDromajoCosimBlackBox
                         inst[((__itr+1)*INST_BITS - 1)-:INST_BITS],
                         wdata[((__itr+1)*XLEN - 1)-:XLEN],
                         mstatus[((__itr+1)*XLEN - 1)-:XLEN],
-                        check[__itr]);
+                        check[__itr],
+                        wdata_valid[__itr],
+                        wdata_dest[((__itr+1)*RD - 1)-:RD]);
                     if (__fail != 0) begin
                         $display("FAIL: Dromajo Simulation Failed with exit code: %d", __fail);
                         $fatal;

--- a/src/main/scala/Dromajo.scala
+++ b/src/main/scala/Dromajo.scala
@@ -73,7 +73,7 @@ class SimDromajoBridge(insnWidths: TracedInstructionWidths, numInsns: Int) exten
 
   dromajo.io.wdata_valid := Cat(traces.map(t => t.wdata_valid.get).reverse)
   dromajo.io.wdata_dest := Cat(traces.map(t => UIntToAugmentedUInt(t.wdata_dest.get).sextTo(DromajoConstants.rd)).reverse)
-  //dromajo.io.insn_writes_back := Cat(traces.map(t => t.insn_writes_back.get).reverse)
+  dromajo.io.insn_writes_back := Cat(traces.map(t => t.insn_writes_back.get).reverse)
 
   // assumes that all interrupt/exception signals are the same throughout all committed instructions
   dromajo.io.int_xcpt := traces(0).interrupt || traces(0).exception
@@ -127,7 +127,7 @@ class SimDromajoCosimBlackBox(commitWidth: Int)
     
     val wdata_valid = Input(UInt((commitWidth).W))
     val wdata_dest = Input(UInt((rd*commitWidth).W))
-    //val insn_writes_back = Input(UInt((commitWidth).W))
+    val insn_writes_back = Input(UInt((commitWidth).W))
 
     //wdata_dest
     //insn_wdata_dest

--- a/src/main/scala/Dromajo.scala
+++ b/src/main/scala/Dromajo.scala
@@ -74,6 +74,7 @@ class SimDromajoBridge(insnWidths: TracedInstructionWidths, numInsns: Int) exten
   dromajo.io.wdata_valid := Cat(traces.map(t => t.wdata_valid.get).reverse)
   dromajo.io.wdata_dest := Cat(traces.map(t => UIntToAugmentedUInt(t.wdata_dest.get).sextTo(DromajoConstants.rd)).reverse)
   dromajo.io.insn_writes_back := Cat(traces.map(t => t.insn_writes_back.get).reverse)
+  dromajo.io.insn_wdata_dest := Cat(traces.map(t => UIntToAugmentedUInt(t.insn_wdata_dest.get).sextTo(DromajoConstants.rd)).reverse)
 
   // assumes that all interrupt/exception signals are the same throughout all committed instructions
   dromajo.io.int_xcpt := traces(0).interrupt || traces(0).exception
@@ -128,10 +129,7 @@ class SimDromajoCosimBlackBox(commitWidth: Int)
     val wdata_valid = Input(UInt((commitWidth).W))
     val wdata_dest = Input(UInt((rd*commitWidth).W))
     val insn_writes_back = Input(UInt((commitWidth).W))
-
-    //wdata_dest
-    //insn_wdata_dest
-    //insn_wb?
+    val insn_wdata_dest = Input(UInt((rd*commitWidth).W))
 
     val int_xcpt = Input(      Bool())
     val cause    = Input(UInt(xLen.W))

--- a/src/main/scala/TraceIO.scala
+++ b/src/main/scala/TraceIO.scala
@@ -164,7 +164,7 @@ object TraceOutputTop {
 
 trait WithExtendedTraceport { this: BaseTile =>
   // Extended Traceport
-  val extTraceSourceNode = BundleBridgeSource(() => Vec(tileParams.core.retireWidth, new ExtendedTracedInstruction()))
+  val extTraceSourceNode = BundleBridgeSource(() => Vec(tileParams.core.retireWidth + 2, new ExtendedTracedInstruction()))
   val extTraceNode = BundleBroadcast[Vec[ExtendedTracedInstruction]](Some("trace"))
   extTraceNode := extTraceSourceNode
 }

--- a/src/main/scala/TraceIO.scala
+++ b/src/main/scala/TraceIO.scala
@@ -36,6 +36,7 @@ class ExtendedTracedInstruction(val extended: Boolean = true)(implicit p: Parame
   val wdata_dest = if (extended) Some(UInt(5.W)) else None //CoreMonitorBundle.wrdst
 
   val insn_writes_back = if (extended) Some(Bool()) else None
+  val insn_wdata_dest = if (extended) Some(UInt(5.W)) else None
   //val wdata = Some(UInt(xLen.W))
   //wdata corresponds to instr in TracedInstr bundle
   //need to allow break this assumption & tell dromajo abt wdata in any order (dromajo recover order before feeding to simulator)
@@ -92,6 +93,7 @@ class DeclockedTracedInstruction(val widths: TracedInstructionWidths, val extend
   val wdata_valid = if (extended) Some(Bool()) else None
   val wdata_dest = if (extended) Some(UInt(5.W)) else None //CoreMonitorBundle.wrdst
   val insn_writes_back = if (extended) Some(Bool()) else None
+  val insn_wdata_dest = if (extended) Some(UInt(5.W)) else None
 }
 
 object DeclockedTracedInstruction {
@@ -118,6 +120,7 @@ object DeclockedTracedInstruction {
       declocked.wdata_valid.get := clocked.wdata_valid.get
       declocked.wdata_dest.get := clocked.wdata_dest.get
       declocked.insn_writes_back.get := clocked.insn_writes_back.get
+      declocked.insn_wdata_dest.get := clocked.insn_wdata_dest.get
     })
     VecInit(declockedVec)
   }

--- a/src/main/scala/TraceIO.scala
+++ b/src/main/scala/TraceIO.scala
@@ -165,7 +165,9 @@ object TraceOutputTop {
 trait WithExtendedTraceport { this: BaseTile =>
   // Extended Traceport
   val extTraceSourceNode = BundleBridgeSource(() => Vec(tileParams.core.retireWidth + 2, new ExtendedTracedInstruction()))
+  //val extTraceSourceNode = BundleBridgeSource(() => Vec(tileParams.core.retireWidth, new ExtendedTracedInstruction()))
   val extTraceNode = BundleBroadcast[Vec[ExtendedTracedInstruction]](Some("trace"))
+  
   extTraceNode := extTraceSourceNode
 }
 

--- a/src/main/scala/TraceIO.scala
+++ b/src/main/scala/TraceIO.scala
@@ -165,7 +165,7 @@ object TraceOutputTop {
 trait WithExtendedTraceport { this: BaseTile =>
   // Extended Traceport
   val extTraceSourceNode = BundleBridgeSource(() => Vec(tileParams.core.retireWidth + 2, new ExtendedTracedInstruction()))
-  //val extTraceSourceNode = BundleBridgeSource(() => Vec(tileParams.core.retireWidth, new ExtendedTracedInstruction()))
+  // val extTraceSourceNode = BundleBridgeSource(() => Vec(tileParams.core.retireWidth, new ExtendedTracedInstruction()))
   val extTraceNode = BundleBroadcast[Vec[ExtendedTracedInstruction]](Some("trace"))
   
   extTraceNode := extTraceSourceNode


### PR DESCRIPTION
Add Dromajo support for the old version of Saturn-V.  
- make a new ExtendedTracedInstruction to encapsulate the signals needed to be passed out of the Saturn core.
- Pass the signals from the Saturn core 
- reorder out-of-order instructions from Saturn-V. through a buffer and pass the re-ordered instruction into the Dromajo simulator

Depends on changes made in:
https://github.com/ucb-bar/saturn/pull/26
- Construct trace signals from Saturn-V (for use in Dromajo).

https://github.com/chipsalliance/dromajo/pull/72
- toggle Dromajo simulator settings to match the settings of the Saturn-V core
