### PR TITLE
Pull common components of testchip_tsi/testchip_dtm into testchip_htif_t

### DIFF
--- a/src/main/resources/testchipip/csrc/testchip_dtm.cc
+++ b/src/main/resources/testchipip/csrc/testchip_dtm.cc
@@ -97,6 +97,7 @@ testchip_dtm_t::testchip_dtm_t(int argc, char** argv, bool can_have_loadmem) : d
     if (arg.find("+loadarch=") == 0)
       loadarch_file = arg.substr(strlen("+loadarch="));
   }
+  testchip_htif_t::parse_htif_args(args);
 }
 
 
@@ -224,6 +225,7 @@ void testchip_dtm_t::loadarch_restore_csr(uint32_t regno, reg_t reg) {
 
 void testchip_dtm_t::reset()
 {
+  testchip_htif_t::perform_init_accesses();
   if (loadarch_file != "") {
     printf("loadarch attempting to load architectural state from %s\n", loadarch_file.c_str());
     std::string line;
@@ -381,7 +383,7 @@ void testchip_dtm_t::reset()
     for (size_t hartsel = 0; hartsel < nharts; hartsel++) {
       resume(hartsel);
     }
-  } else {
+  } else if (write_hart0_msip) {
     // The dtm_t::reset skips the rest of the bootrom
     // Use CLINT to interrupt the core instead
     //dtm_t::reset();

--- a/src/main/resources/testchipip/csrc/testchip_dtm.h
+++ b/src/main/resources/testchipip/csrc/testchip_dtm.h
@@ -5,6 +5,7 @@
 #include <fesvr/dtm.h>
 #include <vector>
 #include <riscv/processor.h>
+#include "testchip_htif.h"
 
 struct loadarch_state_t {
   reg_t pc;
@@ -49,7 +50,7 @@ struct loadarch_state_t {
   unsigned char* VPR[32];
 };
 
-class testchip_dtm_t : public dtm_t
+class testchip_dtm_t : public dtm_t, public testchip_htif_t
 {
  public:
   testchip_dtm_t(int argc, char** argv, bool has_loadmem);

--- a/src/main/resources/testchipip/csrc/testchip_htif.cc
+++ b/src/main/resources/testchipip/csrc/testchip_htif.cc
@@ -1,0 +1,38 @@
+#include "testchip_htif.h"
+
+void testchip_htif_t::parse_htif_args(std::vector<std::string> &args) {
+  for (auto& arg : args) {
+    if (arg.find("+init_write=0x") == 0) {
+      auto d = arg.find(":0x");
+      if (d == std::string::npos) {
+        throw std::invalid_argument("Improperly formatted +init_write argument");
+      }
+      uint64_t addr = strtoull(arg.substr(14, d - 14).c_str(), 0, 16);
+      uint32_t val = strtoull(arg.substr(d + 3).c_str(), 0, 16);
+      init_access_t access = { .address=addr, .stdata=val, .store=true };
+      init_accesses.push_back(access);
+    }
+    if (arg.find("+init_read=0x") == 0) {
+      uint64_t addr = strtoull(arg.substr(13).c_str(), 0, 16);
+      init_access_t access = { .address=addr, .stdata=0, .store=false };
+      init_accesses.push_back(access);
+    }
+    if (arg.find("+no_hart0_msip") == 0)
+      write_hart0_msip = false;
+  }
+}
+
+void testchip_htif_t::perform_init_accesses() {
+  for (auto p : init_accesses) {
+    if (p.store) {
+      fprintf(stderr, "Writing %lx with %x\n", p.address, p.stdata);
+      write_chunk(p.address, sizeof(uint32_t), &p.stdata);
+      fprintf(stderr, "Done writing %lx with %x\n", p.address, p.stdata);
+    } else {
+      fprintf(stderr, "Reading %lx ...", p.address);
+      uint32_t rdata = 0;
+      read_chunk(p.address, sizeof(uint32_t), &rdata);
+      fprintf(stderr, " got %x\n", rdata);
+    }
+  }
+}

--- a/src/main/resources/testchipip/csrc/testchip_htif.h
+++ b/src/main/resources/testchipip/csrc/testchip_htif.h
@@ -1,0 +1,29 @@
+#ifndef __TESTCHIP_HTIF_H
+#define __TESTCHIP_HTIF_H
+
+#include <stdexcept>
+#include <stdint.h>
+#include <vector>
+#include <string>
+#include <fesvr/htif.h>
+
+struct init_access_t {
+  uint64_t address;
+  uint32_t stdata;
+  bool store;
+};
+
+class testchip_htif_t
+{
+ public:
+  virtual void write_chunk(addr_t taddr, size_t nbytes, const void* src) = 0;
+  virtual void read_chunk(addr_t taddr, size_t nbytes, void* dst) = 0;
+  virtual ~testchip_htif_t() {};
+
+ protected:
+  void perform_init_accesses();
+  void parse_htif_args(std::vector<std::string> &args);
+  bool write_hart0_msip = true;
+  std::vector<init_access_t> init_accesses;
+};
+#endif

--- a/src/main/resources/testchipip/csrc/testchip_tsi.cc
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.cc
@@ -12,24 +12,9 @@ testchip_tsi_t::testchip_tsi_t(int argc, char** argv, bool can_have_loadmem) : t
   for (auto& arg : args) {
     if (arg.find("+loadmem=") == 0)
       has_loadmem = can_have_loadmem;
-    if (arg.find("+init_write=0x") == 0) {
-      auto d = arg.find(":0x");
-      if (d == std::string::npos) {
-        throw std::invalid_argument("Improperly formatted +init_write argument");
-      }
-      uint64_t addr = strtoull(arg.substr(14, d - 14).c_str(), 0, 16);
-      uint32_t val = strtoull(arg.substr(d + 3).c_str(), 0, 16);
-      init_access_t access = { .address=addr, .stdata=val, .store=true };
-      init_accesses.push_back(access);
-    }
-    if (arg.find("+init_read=0x") == 0) {
-      uint64_t addr = strtoull(arg.substr(13).c_str(), 0, 16);
-      init_access_t access = { .address=addr, .stdata=0, .store=false };
-      init_accesses.push_back(access);
-    }
-    if (arg.find("+no_hart0_msip") == 0)
-      write_hart0_msip = false;
   }
+
+  testchip_htif_t::parse_htif_args(args);
 }
 
 
@@ -53,18 +38,7 @@ void testchip_tsi_t::read_chunk(addr_t taddr, size_t nbytes, void* dst)
 
 void testchip_tsi_t::reset()
 {
-  for (auto p : init_accesses) {
-    if (p.store) {
-      fprintf(stderr, "Writing %lx with %x\n", p.address, p.stdata);
-      write_chunk(p.address, sizeof(uint32_t), &p.stdata);
-      fprintf(stderr, "Done writing %lx with %x\n", p.address, p.stdata);
-    } else {
-      fprintf(stderr, "Reading %lx ...", p.address);
-      uint32_t rdata = 0;
-      read_chunk(p.address, sizeof(uint32_t), &rdata);
-      fprintf(stderr, " got %x\n", rdata);
-    }
-  }
+  testchip_htif_t::perform_init_accesses();
   if (write_hart0_msip)
     tsi_t::reset();
 }

--- a/src/main/resources/testchipip/csrc/testchip_tsi.h
+++ b/src/main/resources/testchipip/csrc/testchip_tsi.h
@@ -5,14 +5,9 @@
 
 #include <fesvr/tsi.h>
 #include <fesvr/htif.h>
+#include "testchip_htif.h"
 
-struct init_access_t {
-  uint64_t address;
-  uint32_t stdata;
-  bool store;
-};
-
-class testchip_tsi_t : public tsi_t
+class testchip_tsi_t : public tsi_t, public testchip_htif_t
 {
  public:
   testchip_tsi_t(int argc, char** argv, bool has_loadmem);
@@ -37,7 +32,5 @@ class testchip_tsi_t : public tsi_t
  private:
 
   bool is_loadmem;
-  bool write_hart0_msip;
-  std::vector<init_access_t> init_accesses;
 };
 #endif

--- a/src/main/scala/SimDTM.scala
+++ b/src/main/scala/SimDTM.scala
@@ -26,6 +26,8 @@ class TestchipSimDTM(implicit p: Parameters) extends BlackBox with HasBlackBoxRe
   }
 
   addResource("/testchipip/vsrc/TestchipSimDTM.v")
+  addResource("/testchipip/csrc/testchip_htif.cc")
+  addResource("/testchipip/csrc/testchip_htif.h")
   addResource("/testchipip/csrc/testchip_dtm.cc")
   addResource("/testchipip/csrc/testchip_dtm.h")
 }

--- a/src/main/scala/SimTSI.scala
+++ b/src/main/scala/SimTSI.scala
@@ -32,6 +32,8 @@ class SimTSI extends BlackBox with HasBlackBoxResource {
 
   addResource("/testchipip/vsrc/SimTSI.v")
   addResource("/testchipip/csrc/SimTSI.cc")
+  addResource("/testchipip/csrc/testchip_htif.cc")
+  addResource("/testchipip/csrc/testchip_htif.h")
   addResource("/testchipip/csrc/testchip_tsi.cc")
   addResource("/testchipip/csrc/testchip_tsi.h")
 }

--- a/uart_tsi/Makefile
+++ b/uart_tsi/Makefile
@@ -1,7 +1,9 @@
 
 default: uart_tsi
 
-uart_tsi: testchip_uart_tsi.cc ../src/main/resources/testchipip/csrc/testchip_tsi.cc
+SRCS = $(addprefix ../src/main/resources/testchipip/csrc/,testchip_tsi.cc testchip_htif.cc)
+
+uart_tsi: testchip_uart_tsi.cc $(SRCS)
 	g++ -O3 -L $(RISCV)/lib -I ../src/main/resources/testchipip/csrc -I $(RISCV)/include -std=c++17 -o $@ $^ -lfesvr -lpthread
 
 clean:


### PR DESCRIPTION
This enables the `+init_read/+init_write/+no_hart0_msip` custom features for both dmi and tsi bringup.