### PR TITLE
Remove implicit Parameters from some harness blocks

### DIFF
--- a/src/main/scala/SPIFlash.scala
+++ b/src/main/scala/SPIFlash.scala
@@ -6,7 +6,7 @@ import chisel3.experimental.{Analog, IntParam, StringParam}
 
 import org.chipsalliance.cde.config.{Parameters}
 import freechips.rocketchip.util.{PlusArgArtefacts}
-import sifive.blocks.devices.spi.{PeripherySPIFlashKey}
+import sifive.blocks.devices.spi.{PeripherySPIFlashKey, SPIFlashParams}
 
 class SPIChipIO(val csWidth: Int = 1) extends Bundle {
   val sck = Output(Bool())
@@ -74,8 +74,8 @@ class SPIFlashMemCtrl(addrBits: Int) extends BlackBox(Map(
 }
 
 object SimSPIFlashModel {
-  def connect(spi: Seq[SPIChipIO], reset: Reset, rdOnly: Boolean = true)(implicit p: Parameters) {
-    spi.zip(p(PeripherySPIFlashKey)).zipWithIndex.foreach { case ((port, params), i) =>
+  def connect(spi: Seq[SPIChipIO], reset: Reset, rdOnly: Boolean = true, params: SPIFlashParams) = {
+    spi.zipWithIndex.foreach { case (port, i) =>
       val spi_mem = Module(new SimSPIFlashModel(params.fSize, i, rdOnly))
       spi_mem.suggestName(s"spi_mem_${i}")
       spi_mem.io.sck := port.sck

--- a/src/main/scala/Unittests.scala
+++ b/src/main/scala/Unittests.scala
@@ -13,6 +13,7 @@ import scala.math.max
 
 class BlockDeviceTrackerTestDriver(nSectors: Int)(implicit p: Parameters)
     extends LazyModule with HasBlockDeviceParameters {
+  val bdParams = p(BlockDeviceKey).get
   val node = TLClientNode(Seq(TLMasterPortParameters.v1(Seq(TLClientParameters(
     name = "blkdev-testdriver", sourceId = IdRange(0, 1))))))
 
@@ -83,6 +84,7 @@ class BlockDeviceTrackerTestDriver(nSectors: Int)(implicit p: Parameters)
 
 class BlockDeviceTrackerTest(implicit p: Parameters) extends LazyModule
     with HasBlockDeviceParameters {
+  val bdParams = p(BlockDeviceKey).get
   val nSectors = 4
   val beatBytes = dataBitsPerBeat / 8
 
@@ -107,7 +109,7 @@ class BlockDeviceTrackerTest(implicit p: Parameters) extends LazyModule
 
   lazy val module = new LazyModuleImp(this) with HasUnitTestIO {
     val io = IO(new Bundle with UnitTestIO)
-    val blkdev = Module(new BlockDeviceModel(nSectors))
+    val blkdev = Module(new BlockDeviceModel(nSectors, bdParams))
     blkdev.io <> tracker.module.io.bdev
     tracker.module.io.front <> driver.module.io.front
     driver.module.io.start := io.start


### PR DESCRIPTION
This brings the API in-line with the Port API in CY, which will not pass around Parameters from the SoC to the harness.