### PR TITLE
Split debug_tick from rest of code

### DIFF
--- a/src/main/resources/testchipip/csrc/TestchipSimDTM.cc
+++ b/src/main/resources/testchipip/csrc/TestchipSimDTM.cc
@@ -1,0 +1,44 @@
+// See LICENSE.SiFive for license details.
+
+#include "testchip_dtm.h"
+#include <vpi_user.h>
+#include <svdpi.h>
+
+testchip_dtm_t* dtm;
+
+extern "C" int debug_tick
+(
+  unsigned char* debug_req_valid,
+  unsigned char  debug_req_ready,
+  int*           debug_req_bits_addr,
+  int*           debug_req_bits_op,
+  int*           debug_req_bits_data,
+  unsigned char  debug_resp_valid,
+  unsigned char* debug_resp_ready,
+  int            debug_resp_bits_resp,
+  int            debug_resp_bits_data
+)
+{
+  if (!dtm) {
+    s_vpi_vlog_info info;
+    if (!vpi_get_vlog_info(&info))
+      abort();
+    dtm = new testchip_dtm_t(info.argc, info.argv, true); // TODO: only support loadmem if we have loadmem
+  }
+
+  dtm_t::resp resp_bits;
+  resp_bits.resp = debug_resp_bits_resp;
+  resp_bits.data = debug_resp_bits_data;
+
+  dtm->tick(debug_req_ready,
+	    debug_resp_valid,
+	    resp_bits);
+
+  *debug_resp_ready = dtm->resp_ready();
+  *debug_req_valid = dtm->req_valid();
+  *debug_req_bits_addr = dtm->req_bits().addr;
+  *debug_req_bits_op = dtm->req_bits().op;
+  *debug_req_bits_data = dtm->req_bits().data;
+
+  return dtm->done() ? (dtm->exit_code() << 1 | 1) : 0;
+}

--- a/src/main/resources/testchipip/csrc/testchip_dtm.cc
+++ b/src/main/resources/testchipip/csrc/testchip_dtm.cc
@@ -4,8 +4,6 @@
 #include <riscv/encoding.h>
 #include <fesvr/dtm.h>
 #include <riscv/debug_defines.h>
-#include <vpi_user.h>
-#include <svdpi.h>
 #include <fstream>
 #include <vector>
 
@@ -45,45 +43,6 @@
 #define MSIP_BASE 0x2000000
 
 #define MAX_VLEN (8 * 32) // Limited by debug module capacity
-
-testchip_dtm_t* dtm;
-
-extern "C" int debug_tick
-(
-  unsigned char* debug_req_valid,
-  unsigned char  debug_req_ready,
-  int*           debug_req_bits_addr,
-  int*           debug_req_bits_op,
-  int*           debug_req_bits_data,
-  unsigned char  debug_resp_valid,
-  unsigned char* debug_resp_ready,
-  int            debug_resp_bits_resp,
-  int            debug_resp_bits_data
-)
-{
-  if (!dtm) {
-    s_vpi_vlog_info info;
-    if (!vpi_get_vlog_info(&info))
-      abort();
-    dtm = new testchip_dtm_t(info.argc, info.argv, true); // TODO: only support loadmem if we have loadmem
-  }
-
-  dtm_t::resp resp_bits;
-  resp_bits.resp = debug_resp_bits_resp;
-  resp_bits.data = debug_resp_bits_data;
-
-  dtm->tick(debug_req_ready,
-	    debug_resp_valid,
-	    resp_bits);
-
-  *debug_resp_ready = dtm->resp_ready();
-  *debug_req_valid = dtm->req_valid();
-  *debug_req_bits_addr = dtm->req_bits().addr;
-  *debug_req_bits_op = dtm->req_bits().op;
-  *debug_req_bits_data = dtm->req_bits().data;
-
-  return dtm->done() ? (dtm->exit_code() << 1 | 1) : 0;
-}
 
 testchip_dtm_t::testchip_dtm_t(int argc, char** argv, bool can_have_loadmem) : dtm_t(argc, argv), loadarch_done(false)
 {

--- a/src/main/scala/SimDTM.scala
+++ b/src/main/scala/SimDTM.scala
@@ -30,4 +30,5 @@ class TestchipSimDTM(implicit p: Parameters) extends BlackBox with HasBlackBoxRe
   addResource("/testchipip/csrc/testchip_htif.h")
   addResource("/testchipip/csrc/testchip_dtm.cc")
   addResource("/testchipip/csrc/testchip_dtm.h")
+  addResource("/testchipip/csrc/TestchipSimDTM.cc")
 }


### PR DESCRIPTION
Matches what other debug interfaces (i.e. TSI) do. Needed so that C code that inherits from `testchip_dtm.*` but doesn't have VPI headers can compile.