### PR TITLE
Add config/class to instantiate our own EICG_wrapper

### DIFF
--- a/src/main/scala/ClockUtil.scala
+++ b/src/main/scala/ClockUtil.scala
@@ -7,6 +7,11 @@ import chisel3.experimental.{Analog, IntParam}
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.util._
 
+// This always adds the resource always
+class EICG_wrapper extends ClockGate {
+   addResource("/vsrc/EICG_wrapper.v")
+}
+
 class ClockFlop extends BlackBox with HasBlackBoxResource {
     val io = IO(new Bundle {
         val clockIn = Input(Clock())

--- a/src/main/scala/Configs.scala
+++ b/src/main/scala/Configs.scala
@@ -8,6 +8,7 @@ import sifive.blocks.devices.uart._
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.diplomacy.{AsynchronousCrossing, ClockCrossingType, AddressSet}
 import freechips.rocketchip.unittest.UnitTests
+import freechips.rocketchip.util.{ClockGateImpl}
 
 class WithRingSystemBus(
     buffer: TLNetworkBufferParams = TLNetworkBufferParams.default)
@@ -200,3 +201,6 @@ class WithOffchipBusClient(
       OffchipBusTopologyConnectionParams(location, blockRange, replicationBase)
 })
 
+class WithTestChipEICGWrapper extends Config((site, here, up) => {
+   case ClockGateImpl => () => new testchipip.EICG_wrapper
+})


### PR DESCRIPTION
The Rocket-chip one sometimes doesn't include the resource file, ours always does