### PR TITLE
Add Chip ID Pin

### DIFF
--- a/src/main/scala/soc/ChipIdPin.scala
+++ b/src/main/scala/soc/ChipIdPin.scala
@@ -9,8 +9,8 @@ import freechips.rocketchip.regmapper._
 import freechips.rocketchip.subsystem._
 
 case class ChipIdPinParams (
-  numChips: Int = 1, 
-  chipIdAddr: BigInt = 0x2000, //TODO: pick addr
+  width: Int = 1, 
+  chipIdAddr: BigInt = 0x2000,
   slaveWhere: TLBusWrapperLocation = CBUS
 )
 
@@ -20,22 +20,21 @@ trait CanHavePeripheryChipIdPin { this: BaseSubsystem =>
   val chip_id_pin = p(ChipIdPinKey).map { params => 
     val tlbus = locateTLBusWrapper(params.slaveWhere)
     val device = new SimpleDevice("chip-id-reg", Nil)
-    val id_bits = log2Up(params.numChips)
 
     val inner_io = tlbus {
       val node = TLRegisterNode(
-        address = Seq(AddressSet(params.chipIdAddr, 0xfff)), //TODO: fix address set size
+        address = Seq(AddressSet(params.chipIdAddr, 4096 - 1)),
         device = device, 
         beatBytes=tlbus.beatBytes)
       tlbus.coupleTo(s"chip-id-reg"){ node := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := _ }
       InModuleBody {
-        val chip_id = IO(Input(UInt(id_bits.W))).suggestName("chip_id") 
+        val chip_id = IO(Input(UInt(params.width.W))).suggestName("chip_id") 
         node.regmap(0 -> Seq(RegField.r(64, chip_id)))
         chip_id
       }
     }
     val outer_io = InModuleBody {
-      val chip_id = IO(Input(UInt(id_bits.W))).suggestName("chip_id")
+      val chip_id = IO(Input(UInt(params.width.W))).suggestName("chip_id")
       inner_io := chip_id
       chip_id
     }

--- a/src/main/scala/soc/ChipIdPin.scala
+++ b/src/main/scala/soc/ChipIdPin.scala
@@ -1,0 +1,44 @@
+package testchipip.soc
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config._
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.regmapper._
+import freechips.rocketchip.subsystem._
+
+case class ChipIdPinParams (
+  numChips: Int = 1, 
+  chipIdAddr: BigInt = 0x2000, //TODO: pick addr
+  slaveWhere: TLBusWrapperLocation = CBUS
+)
+
+case object ChipIdPinKey extends Field[Option[ChipIdPinParams]](None)
+
+trait CanHavePeripheryChipIdPin { this: BaseSubsystem =>
+  val chip_id_pin = p(ChipIdPinKey).map { params => 
+    val tlbus = locateTLBusWrapper(params.slaveWhere)
+    val device = new SimpleDevice("chip-id-reg", Nil)
+    val id_bits = log2Up(params.numChips)
+
+    val inner_io = tlbus {
+      val node = TLRegisterNode(
+        address = Seq(AddressSet(params.chipIdAddr, 0xfff)), //TODO: fix address set size
+        device = device, 
+        beatBytes=tlbus.beatBytes)
+      tlbus.coupleTo(s"chip-id-reg"){ node := TLFragmenter(tlbus.beatBytes, tlbus.blockBytes) := _ }
+      InModuleBody {
+        val chip_id = IO(Input(UInt(id_bits.W))).suggestName("chip_id") 
+        node.regmap(0 -> Seq(RegField.r(64, chip_id)))
+        chip_id
+      }
+    }
+    val outer_io = InModuleBody {
+      val chip_id = IO(Input(UInt(id_bits.W))).suggestName("chip_id")
+      inner_io := chip_id
+      chip_id
+    }
+    outer_io
+  }
+}

--- a/src/main/scala/soc/Configs.scala
+++ b/src/main/scala/soc/Configs.scala
@@ -67,6 +67,19 @@ class WithOffchipBusClient(
       OffchipBusTopologyConnectionParams(location, blockRange, replicationBase)
 })
 
+//-------------------------
+// ChipIdPin Configs
+//-------------------------
+
+class WithChipIdPin(params: ChipIdPinParams = ChipIdPinParams()) extends Config((site, here, up) => {
+  case ChipIdPinKey => Some(params)
+})
+
+// Used for setting pin width
+class WithChipIdPinNumChips(numChips: Int) extends Config((site, here, up) => {
+  case ChipIdPinKey => up(ChipIdPinKey, site).map(p => p.copy(numChips = numChips))
+})
+
 // Deprecated: use Constellation's network-on-chip generators instead of this
 class WithRingSystemBus(
     buffer: TLNetworkBufferParams = TLNetworkBufferParams.default)

--- a/src/main/scala/soc/Configs.scala
+++ b/src/main/scala/soc/Configs.scala
@@ -76,8 +76,8 @@ class WithChipIdPin(params: ChipIdPinParams = ChipIdPinParams()) extends Config(
 })
 
 // Used for setting pin width
-class WithChipIdPinNumChips(numChips: Int) extends Config((site, here, up) => {
-  case ChipIdPinKey => up(ChipIdPinKey, site).map(p => p.copy(numChips = numChips))
+class WithChipIdPinWidth(width: Int) extends Config((site, here, up) => {
+  case ChipIdPinKey => up(ChipIdPinKey, site).map(p => p.copy(width = width))
 })
 
 // Deprecated: use Constellation's network-on-chip generators instead of this


### PR DESCRIPTION
Adds a pin to set the chip id for each chip. The pin drives a read-only MMIO register attached to the CBUS.

The purpose of adding this pin is to enable cache coherency across multi-chip configs in Chipyard.