### PR TITLE
Update deprecated APIs to prepare for Chisel 5

### DIFF
--- a/src/main/scala/boot/CustomBootPin.scala
+++ b/src/main/scala/boot/CustomBootPin.scala
@@ -2,7 +2,6 @@ package testchipip.boot
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{IO}
 import org.chipsalliance.cde.config._
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/boot/TileResetCtrl.scala
+++ b/src/main/scala/boot/TileResetCtrl.scala
@@ -1,7 +1,6 @@
 package testchipip.boot
 
 import chisel3._
-import chisel3.experimental.{IO}
 import org.chipsalliance.cde.config.{Parameters, Field}
 import freechips.rocketchip.diplomacy._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/cosim/Cospike.scala
+++ b/src/main/scala/cosim/Cospike.scala
@@ -1,7 +1,7 @@
 package testchipip.cosim
 
 import chisel3._
-import chisel3.experimental.{IntParam, StringParam, IO}
+import chisel3.experimental.{IntParam, StringParam}
 import chisel3.util._
 
 import freechips.rocketchip.subsystem._

--- a/src/main/scala/iceblk/BlockDevice.scala
+++ b/src/main/scala/iceblk/BlockDevice.scala
@@ -1,7 +1,7 @@
 package testchipip.iceblk
 
 import chisel3._
-import chisel3.experimental.{IntParam, IO}
+import chisel3.experimental.{IntParam}
 import chisel3.util._
 import org.chipsalliance.cde.config.{Field, Parameters}
 import freechips.rocketchip.subsystem.{CacheBlockBytes, BaseSubsystem, TLBusWrapperLocation, PBUS, FBUS}

--- a/src/main/scala/serdes/Adapter.scala
+++ b/src/main/scala/serdes/Adapter.scala
@@ -19,7 +19,7 @@ class SerialWidthAggregator(narrowW: Int, wideW: Int) extends Module {
   val narrow_data = Reg(Vec(beats-1, UInt(narrowW.W)))
 
   io.narrow.ready := Mux(narrow_last_beat, io.wide.ready, true.B)
-  when (io.narrow.fire()) {
+  when (io.narrow.fire) {
     narrow_beats := Mux(narrow_last_beat, 0.U, narrow_beats + 1.U)
     when (!narrow_last_beat) { narrow_data(narrow_beats) := io.narrow.bits }
   }
@@ -41,7 +41,7 @@ class SerialWidthSlicer(narrowW: Int, wideW: Int) extends Module {
 
   io.narrow.valid := io.wide.valid
   io.narrow.bits := io.wide.bits.asTypeOf(Vec(beats, UInt(narrowW.W)))(wide_beats)
-  when (io.narrow.fire()) {
+  when (io.narrow.fire) {
     wide_beats := Mux(wide_last_beat, 0.U, wide_beats + 1.U)
   }
   io.wide.ready := wide_last_beat && io.narrow.ready

--- a/src/main/scala/serdes/PeripheryTLSerial.scala
+++ b/src/main/scala/serdes/PeripheryTLSerial.scala
@@ -2,7 +2,6 @@ package testchipip.serdes
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{IO}
 import org.chipsalliance.cde.config.{Parameters, Field}
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/soc/OffchipBus.scala
+++ b/src/main/scala/soc/OffchipBus.scala
@@ -2,7 +2,6 @@ package testchipip.soc
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{IO, DataMirror}
 import org.chipsalliance.cde.config.{Parameters, Field}
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/tsi/TSIHarness.scala
+++ b/src/main/scala/tsi/TSIHarness.scala
@@ -2,7 +2,6 @@ package testchipip.tsi
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{IO, DataMirror}
 import org.chipsalliance.cde.config.{Parameters, Field}
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/tsi/TSIToTileLink.scala
+++ b/src/main/scala/tsi/TSIToTileLink.scala
@@ -2,7 +2,6 @@ package testchipip.tsi
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{IO}
 import org.chipsalliance.cde.config.{Parameters, Field}
 import freechips.rocketchip.subsystem._
 import freechips.rocketchip.tilelink._

--- a/src/main/scala/util/Util.scala
+++ b/src/main/scala/util/Util.scala
@@ -2,7 +2,7 @@ package testchipip.util
 
 import chisel3._
 import chisel3.util._
-import chisel3.experimental.{DataMirror}
+import chisel3.reflect.DataMirror
 import org.chipsalliance.cde.config.Parameters
 import freechips.rocketchip.diplomacy.{IdRange, ValName, LazyModule, LazyModuleImp}
 import freechips.rocketchip.util.AsyncResetReg


### PR DESCRIPTION
- `IO` was moved from `chisel3.experimental` to `chisel3`
- Calls to `fire` with empty parens need the parens removed
- `DataMirror` was moved from `chisel3.experimental` to `chisel3.reflect`