### PR TITLE
Bug fix; Simulation does not wait for chip to come out of reset

### DIFF
--- a/src/main/scala/serdes/SerialPhy.scala
+++ b/src/main/scala/serdes/SerialPhy.scala
@@ -53,8 +53,15 @@ class DecoupledSerialPhy(channels: Int, phyParams: SerialPhyParams) extends RawM
   val in_demux = withClockAndReset(io.outer_clock, io.outer_reset) {
     Module(new PhitDemux(phyParams.phitWidth, phyParams.flitWidth, channels))
   }
+
   in_demux.io.in <> io.outer_ser.in
   in_demux.io.out <> in_phits
+
+  // Prevent accepting data from external world when in reset
+  when (io.outer_reset) {
+    io.outer_ser.in.ready  := false.B
+    io.outer_ser.out.valid := false.B
+  }
 }
 
 class CreditedSerialPhy(channels: Int, phyParams: SerialPhyParams) extends RawModule {


### PR DESCRIPTION
Add guard around outer interface to prevent accepting/transmit from/to the external world of TL serial interface. The chip now waits for the chip to come out of reset before driving the ready for the incoming data, and valid for the data coming from outside the chip to inside the chip. 