### PR TITLE
Cosim should respect DUT's status xs/fs/vs bits

### DIFF
--- a/src/main/resources/testchipip/csrc/cospike_impl.cc
+++ b/src/main/resources/testchipip/csrc/cospike_impl.cc
@@ -511,7 +511,21 @@ int cospike_cosim(long long int cycle,
                          )) {
 	  if (cospike_printf) COSPIKE_PRINTF("CSR override\n");
           s->XPR.write(rd, wdata);
-        } else if (ignore_read)  {
+        } else if (csr_read && ((csr_addr == 0x100) ||               // sstatus
+                                (csr_addr == 0x200) ||               // vsstatus
+                                (csr_addr == 0x300) ||               // mstatus
+                                (csr_addr == 0x600)                  // hstatus
+                                )) {
+          if (cospike_printf) COSPIKE_PRINTF("CSR status override\n");
+          s->XPR.write(rd, wdata);
+          uint64_t ignore_bits = MSTATUS64_SD | MSTATUS_XS | MSTATUS_FS | MSTATUS_VS;
+          s->csrmap[csr_addr]->write(wdata);
+          if ((wdata & ~ignore_bits) != (regwrite.second.v[0] & ~ignore_bits)) {
+            COSPIKE_PRINTF("%lld wdata mismatch reg %d %lx != %llx\n", cycle, rd,
+                           regwrite.second.v[0], wdata);
+            return 1;
+          }
+	} else if (ignore_read)  {
           // Don't check reads from tohost, reads from magic memory, or reads
           // from clint Technically this could be buggy because log_mem_read
           // only reports vaddrs, but no software ever should access


### PR DESCRIPTION
Different approach to #237, but I think this works better.