### PR TITLE
Improve cospike API for multiple memory regions

### DIFF
--- a/src/main/resources/testchipip/csrc/cospike.cc
+++ b/src/main/resources/testchipip/csrc/cospike.cc
@@ -66,3 +66,9 @@ extern "C" void cospike_cosim_wrapper(long long int cycle,
   );
   if (rval) exit(rval);
 }
+
+extern "C" void cospike_register_memory_wrapper(long long int base,
+                                                long long int size)
+{
+  cospike_register_memory(base, size);
+}

--- a/src/main/resources/testchipip/csrc/cospike_impl.cc
+++ b/src/main/resources/testchipip/csrc/cospike_impl.cc
@@ -83,6 +83,7 @@ private:
 };
 
 system_info_t* info = NULL;
+std::vector<std::pair<uint64_t, uint64_t>> mem_info;
 sim_t* sim = NULL;
 bool cospike_debug;
 bool cospike_enable = true;
@@ -103,6 +104,18 @@ static std::vector<std::pair<reg_t, abstract_mem_t*>> make_mems(const std::vecto
     mems.push_back(std::make_pair(cfg.get_base(), new mem_t(cfg.get_size())));
   }
   return mems;
+}
+
+bool mem_already_exists(uint64_t base, uint64_t size) {
+  return std::any_of(mem_info.begin(), mem_info.end(), [base, size](const std::pair<uint64_t, uint64_t>& p) {
+    bool match = p.first == base;
+    if (match && p.second != size) {
+      COSPIKE_PRINTF("Conflicting mem config with legacy API (%lx, %lx) != (%lx, %lx)\n",
+                     p.first, p.second, base, size);
+      exit(1);
+    }
+    return match;
+  });
 }
 
 void cospike_set_sysinfo(char* isa, char* priv, int pmpregions, int maxpglevels,
@@ -155,17 +168,27 @@ void cospike_set_sysinfo(char* isa, char* priv, int pmpregions, int maxpglevels,
   }
 }
 
+void cospike_register_memory(unsigned long long int base,
+                             unsigned long long int size)
+{
+  if (sim) {
+    COSPIKE_PRINTF("Memories must be registered prior to sim execution\n");
+    exit(1);
+  }
+  mem_info.push_back(std::make_pair(base, size));
+}
+
 int cospike_cosim(unsigned long long int cycle,
-                              unsigned long long int hartid,
-                              int has_wdata,
-                              int valid,
-                              unsigned long long int iaddr,
-                              unsigned long int insn,
-                              int raise_exception,
-                              int raise_interrupt,
-                              unsigned long long int cause,
-                              unsigned long long int wdata,
-                              int priv)
+                  unsigned long long int hartid,
+                  int has_wdata,
+                  int valid,
+                  unsigned long long int iaddr,
+                  unsigned long int insn,
+                  int raise_exception,
+                  int raise_interrupt,
+                  unsigned long long int cause,
+                  unsigned long long int wdata,
+                  int priv)
 {
   assert(info);
 
@@ -178,11 +201,17 @@ int cospike_cosim(unsigned long long int cycle,
     COSPIKE_PRINTF("Configuring spike cosim\n");
     std::vector<mem_cfg_t> mem_cfg;
     std::vector<size_t> hartids;
-    mem_cfg.push_back(mem_cfg_t(info->mem0_base, info->mem0_size));
-    if (info->mem1_base != 0)
+    for (auto &t : mem_info)
+      mem_cfg.push_back(mem_cfg_t(t.first, t.second));
+
+    // legacy mem API
+    if (info->mem0_base != 0 && !mem_already_exists(info->mem0_base, info->mem0_size))
+      mem_cfg.push_back(mem_cfg_t(info->mem0_base, info->mem0_size));
+    if (info->mem1_base != 0 && !mem_already_exists(info->mem1_base, info->mem1_size))
       mem_cfg.push_back(mem_cfg_t(info->mem1_base, info->mem1_size));
-    if (info->mem2_base != 0)
+    if (info->mem2_base != 0 && !mem_already_exists(info->mem2_base, info->mem2_size))
       mem_cfg.push_back(mem_cfg_t(info->mem2_base, info->mem2_size));
+
     for (int i = 0; i < info->nharts; i++)
       hartids.push_back(i);
 
@@ -304,12 +333,10 @@ int cospike_cosim(unsigned long long int cycle,
     COSPIKE_PRINTF("Fromhost addr : %" PRIx64 "\n", fromhost_addr);
     COSPIKE_PRINTF("BootROM base  : %" PRIx64 "\n", default_boot_rom_addr);
     COSPIKE_PRINTF("BootROM size  : %" PRIx64 "\n", boot_rom->contents().size());
-    COSPIKE_PRINTF("Memory0 base  : %" PRIx64 "\n", info->mem0_base);
-    COSPIKE_PRINTF("Memory0 size  : %" PRIx64 "\n", info->mem0_size);
-    COSPIKE_PRINTF("Memory1 base  : %" PRIx64 "\n", info->mem1_base);
-    COSPIKE_PRINTF("Memory1 size  : %" PRIx64 "\n", info->mem1_size);
-    COSPIKE_PRINTF("Memory2 base  : %" PRIx64 "\n", info->mem2_base);
-    COSPIKE_PRINTF("Memory2 size  : %" PRIx64 "\n", info->mem2_size);
+    for (auto &cfg : mem_cfg) {
+      COSPIKE_PRINTF("Memory base  : %" PRIx64 "\n", cfg.get_base());
+      COSPIKE_PRINTF("Memory size  : %" PRIx64 "\n", cfg.get_size());
+    }
   }
 
   if (priv & 0x4) { // debug

--- a/src/main/resources/testchipip/csrc/cospike_impl.h
+++ b/src/main/resources/testchipip/csrc/cospike_impl.h
@@ -32,4 +32,8 @@ int cospike_cosim(
   unsigned long long int wdata,
   int priv);
 
+void cospike_register_memory(
+  unsigned long long int base,
+  unsigned long long int size);
+
 #endif // __COSPIKE_IMPL_H

--- a/src/main/resources/testchipip/vsrc/cospike.v
+++ b/src/main/resources/testchipip/vsrc/cospike.v
@@ -26,6 +26,10 @@ import "DPI-C" function void cospike_cosim_wrapper(input longint cycle,
                                            input int     priv
                                            );
 
+import "DPI-C" function void cospike_register_memory_wrapper(input longint base,
+                                                             input longint size
+                                                             );
+
 
 module SpikeCosim  #(
                      parameter ISA,
@@ -91,3 +95,11 @@ module SpikeCosim  #(
       end
    end
 endmodule; // CospikeCosim
+
+module SpikeCosimRegisterMemory #(
+                                  parameter BASE,
+                                  parameter SIZE) ();
+   initial begin
+      cospike_register_memory_wrapper(BASE, SIZE);
+   end;
+endmodule; // SpikeCosimRegisterMemory

--- a/src/main/scala/cosim/Cospike.scala
+++ b/src/main/scala/cosim/Cospike.scala
@@ -14,15 +14,17 @@ case class SpikeCosimConfig(
   priv: String,
   pmpregions: Int,
   maxpglevels: Int,
-  mem0_base: BigInt,
-  mem0_size: BigInt,
   nharts: Int,
   bootrom: String,
   has_dtm: Boolean,
+  mems: Seq[(BigInt, BigInt)],
+  // Legacy APIs
+  mem0_base: BigInt = 0,
+  mem0_size: BigInt = 0,
   mem1_base: BigInt = 0,
   mem1_size: BigInt = 0,
   mem2_base: BigInt = 0,
-  mem2_size: BigInt = 0
+  mem2_size: BigInt = 0,
 )
 
 class SpikeCosim(cfg: SpikeCosimConfig) extends BlackBox(Map(
@@ -64,10 +66,20 @@ class SpikeCosim(cfg: SpikeCosimConfig) extends BlackBox(Map(
   })
 }
 
+class SpikeCosimRegisterMemory(base: BigInt, size: BigInt) extends BlackBox(Map(
+  "BASE" -> IntParam(base),
+  "SIZE" -> IntParam(size)))
+{
+  val io = IO(new Bundle {})
+}
+
 object SpikeCosim
 {
   def apply(trace: TileTraceIO, hartid: Int, cfg: SpikeCosimConfig) = {
     val cosim = Module(new SpikeCosim(cfg))
+    for ((base, size) <- cfg.mems) {
+      val reg = Module(new SpikeCosimRegisterMemory(base, size))
+    }
     val cycle = withClockAndReset(trace.clock, trace.reset) {
       val r = RegInit(0.U(64.W))
       r := r + 1.U
@@ -98,3 +110,4 @@ object SpikeCosim
     }
   }
 }
+


### PR DESCRIPTION
This doesn't remove the legacy `mem0_base/size` field, so firesim+cosim will still work correctly.
At some point the next user of firesim+cosim may want to update the bridge to use the new API, but that can be done in the future.