### PR TITLE
Misc Xcelium fixes

### DIFF
--- a/src/main/resources/testchipip/csrc/SimDRAM.cc
+++ b/src/main/resources/testchipip/csrc/SimDRAM.cc
@@ -22,9 +22,15 @@ extern "C" void *memory_init(
                              long long int line_size,
                              long long int id_bits,
                              long long int clock_hz,
-                             long long int mem_base
+                             long long int mem_base,
+                             int addr_bits
 			     )
 {
+    // in xcelium, while mem_base is a 40b unsigned param, when passed into a long long int DPI variable it becomes signed.
+    // mask off the upper address bits (since we enforce that only address bits worth of address space is available).
+    uint64_t mem_base_mask = (1ULL << addr_bits) - 1;
+    mem_base &= mem_base_mask;
+
     mm_t *mm;
     s_vpi_vlog_info info;
 

--- a/src/main/resources/testchipip/vsrc/SimDRAM.v
+++ b/src/main/resources/testchipip/vsrc/SimDRAM.v
@@ -6,7 +6,8 @@ import "DPI-C" function chandle memory_init
   input longint line_size,
   input longint id_bits,
   input longint clock_hz,
-  input longint mem_base
+  input longint mem_base,
+  input int addr_bits
 );
 
 import "DPI-C" function void memory_tick
@@ -160,7 +161,7 @@ module SimDRAM #(
       __b_valid_reg  <= 1'b0;
     end else begin
       if (!initialized) begin
-        channel = memory_init(CHIP_ID, MEM_SIZE, WORD_SIZE, LINE_SIZE, ID_BITS, CLOCK_HZ, MEM_BASE);
+        channel = memory_init(CHIP_ID, MEM_SIZE, WORD_SIZE, LINE_SIZE, ID_BITS, CLOCK_HZ, MEM_BASE, ADDR_BITS);
         initialized = 1'b1;
       end
 

--- a/src/main/resources/testchipip/vsrc/SimTSI.v
+++ b/src/main/resources/testchipip/vsrc/SimTSI.v
@@ -10,7 +10,7 @@ import "DPI-C" function int tsi_tick
     output int tsi_in_bits
 );
 
-module SimTSI #(parameter CHIPID) (
+module SimTSI #(parameter CHIPID=0) (
     input         clock,
     input         reset,
     input         tsi_out_valid,


### PR DESCRIPTION
Masks of `mem_base` in `SimDRAM.cc` due to a sign extension bug. Also adds a default parameter value for `SimTSI`.