### PR TITLE
Resolve asTypeOf-is-read-only warning

### DIFF
--- a/src/main/scala/serdes/TLSerdes.scala
+++ b/src/main/scala/serdes/TLSerdes.scala
@@ -42,9 +42,9 @@ class TLSerdesser(
       val debug = new SerdesDebugIO
     })
 
-    val client_tl = clientNode.map(_.out(0)._1).getOrElse(0.U.asTypeOf(new TLBundle(bundleParams)))
+    val client_tl = clientNode.map(_.out(0)._1).getOrElse(WireInit(0.U.asTypeOf(new TLBundle(bundleParams))))
     val client_edge = clientNode.map(_.out(0)._2)
-    val manager_tl = managerNode.map(_.in(0)._1).getOrElse(0.U.asTypeOf(new TLBundle(bundleParams)))
+    val manager_tl = managerNode.map(_.in(0)._1).getOrElse(WireInit(0.U.asTypeOf(new TLBundle(bundleParams))))
     val manager_edge = managerNode.map(_.in(0)._2)
 
     val clientParams = client_edge.map(_.bundle).getOrElse(bundleParams)


### PR DESCRIPTION
The current warning:

    [warn] generators/testchipip/src/main/scala/serdes/TLSerdes.scala 85:9: [W008] Return values of asTypeOf will soon be read-only
    [warn]       c <> b.io.protocol
    [warn]         ^

This warning becomes an error in Chisel 7.

More context on this change from Chisel:

- https://github.com/chipsalliance/chisel/pull/4198
- https://github.com/chipsalliance/chisel/blob/48f676b6009377655860ca71e6c008da31c8419a/docs/src/explanations/warnings.md?plain=1#L153

Adding a wire is the recommended fix from `warnings.md`.