### PR TITLE
SimDRAM: Use svGetArrElemPtr1 instead of svGetBitArrElemVecVal

### DIFF
--- a/src/main/resources/testchipip/csrc/SimDRAM.cc
+++ b/src/main/resources/testchipip/csrc/SimDRAM.cc
@@ -142,7 +142,9 @@ extern "C" void memory_tick(
     int w_data_bytes = svSize(w_data, 1);
     unsigned char *w_data_arr = (unsigned char *) malloc(w_data_bytes * sizeof(char));
     for (int i = 0; i < w_data_bytes; i++) {
-        svGetBitArrElemVecVal((svBitVecVal *) (w_data_arr + i), w_data, i);
+        const unsigned char* elem_ptr = static_cast<const unsigned char*>(svGetArrElemPtr1(w_data, i));
+        assert(elem_ptr != nullptr);
+        w_data_arr[i] = *elem_ptr;
     }
 
     mm->tick(


### PR DESCRIPTION
Xcelium doesn't support `svGetBitArrElemVecVal`, and segfaults when that function is executed. Using `svGetArrElemPtr1` should have the same behavior. It returns a pointer to the array element, rather than `svGetBitArrElemVecVal`, which returns a copy of the array element. Also `svGetBitArrElemVecVal` works with a wider variety of bit-array data types, whereas `svGetArrElemPtr1` seems more useful when the underlying datatype can be represented as a native C datatype. Luckily, the underlying SystemVerilog type here is `byte`.