### PR TITLE
Bidirectional Address Translation and CTC Debug Collateral

### DIFF
--- a/src/main/scala/ctc/CTC.scala
+++ b/src/main/scala/ctc/CTC.scala
@@ -33,8 +33,7 @@ case class CTCParams(
   offchip: Seq[AddressSet] = Nil,
   managerBus: Option[TLBusWrapperLocation] = Some(SBUS),
   clientBus: Option[TLBusWrapperLocation] = Some(SBUS),
-  phyFreqMHz: Int = 100,
-  noPhy: Boolean = false
+  phyParams: Option[SerialPhyParams] = Some(CreditedSourceSyncSerialPhyParams(phitWidth = CTC.OUTER_WIDTH, flitWidth = CTC.INNER_WIDTH, freqMHz = 100, flitBufferSz = 16)) // Set to None to disable PHY
 ) {
   def offchipRange = translationParams match {
     case OutwardAddressTranslatorParams(_,_,_) => Seq(translationParams.offchipRange)
@@ -61,12 +60,10 @@ trait CanHavePeripheryCTC { this: BaseSubsystem =>
 
       val ctc_name = s"ctc$id"
 
-      val phyParams = CreditedSourceSyncSerialPhyParams(
-        phitWidth = CTC.OUTER_WIDTH,
-        flitWidth = CTC.INNER_WIDTH,
-        freqMHz = params.phyFreqMHz,
-        flitBufferSz = 16
-      )
+      params.phyParams.map { pP => 
+        assert(pP.phitWidth == CTC.OUTER_WIDTH)
+        assert(pP.flitWidth == CTC.INNER_WIDTH)
+      }
 
       lazy val slave_bus = locateTLBusWrapper(params.managerBus.get)
       lazy val master_bus = locateTLBusWrapper(params.clientBus.get)
@@ -104,48 +101,82 @@ trait CanHavePeripheryCTC { this: BaseSubsystem =>
       }
       
       // If we provide a clock, generate a clock domain for the outgoing clock
-      val serial_tl_clock_freqMHz = CreditedSourceSyncSerialPhyParams().freqMHz
-      val serial_tl_clock_node = ctc_domain { ClockSinkNode(Seq(ClockSinkParameters(take=Some(ClockParameters(serial_tl_clock_freqMHz))))) }
-      serial_tl_clock_node := ClockGroup()(p, ValName(s"${ctc_name}_clock")) := allClockGroupsNode
+      val ctc_clock_freqMHz = params.phyParams match {
+        case Some(param: DecoupledInternalSyncSerialPhyParams) => param.freqMHz
+        case Some(param: DecoupledExternalSyncSerialPhyParams) => 100
+        case Some(param: CreditedSourceSyncSerialPhyParams) => param.freqMHz
+        case None => 100
+      }
+      val ctc_clock_node = ctc_domain { ClockSinkNode(Seq(ClockSinkParameters(take=Some(ClockParameters(ctc_clock_freqMHz))))) }
+      ctc_clock_node := ClockGroup()(p, ValName(s"${ctc_name}_clock")) := allClockGroupsNode
 
       val ctc_outer_io = ctc_domain { InModuleBody {
-        if (params.noPhy) {
-          val flit_io = IO(new CTCBridgeIO).suggestName(ctc_name)
-          flit_io.manager_flit <> tl2ctc.module.io.flit
-          flit_io.client_flit <> ctc2tl.module.io.flit
-          flit_io
-        } else {
-          val phit_io = IO(phyParams.genIO).suggestName(ctc_name)
+        val outer_io = params.phyParams.map(pP => IO(pP.genIO).suggestName(ctc_name)).getOrElse(IO(new CTCBridgeIO).suggestName(ctc_name))
+        
+        outer_io match {
+          case io: CreditedSourceSyncPhitIO => {
+            // 3 clock domains -
+            // - ctc2tl's "Inner clock": synchronizes signals going to the digital logic
+            // - outgoing clock: synchronizes signals going out
+            // - incoming clock: synchronizes signals coming in
+            val outgoing_clock = ctc_clock_node.in.head._1.clock
+            val outgoing_reset = ResetCatchAndSync(outgoing_clock, ctc2tl.module.reset.asBool)
+            val incoming_clock = io.clock_in
+            val incoming_reset = ResetCatchAndSync(incoming_clock, io.reset_in.asBool)
+            io.clock_out := outgoing_clock
+            io.reset_out := outgoing_reset.asAsyncReset
+            val phy = Module(new CreditedSerialPhy(2, params.phyParams.get))
+            phy.io.incoming_clock := incoming_clock
+            phy.io.incoming_reset := incoming_reset
+            phy.io.outgoing_clock := outgoing_clock
+            phy.io.outgoing_reset := outgoing_reset
+            phy.io.inner_clock := ctc2tl.module.clock
+            phy.io.inner_reset := ctc2tl.module.reset
+            phy.io.inner_ser(0).in <> ctc2tl.module.io.flit.in
+            phy.io.inner_ser(0).out <> tl2ctc.module.io.flit.out
+            phy.io.inner_ser(1).in <> tl2ctc.module.io.flit.in
+            phy.io.inner_ser(1).out <> ctc2tl.module.io.flit.out
 
-          // 3 clock domains -
-          // - ctc2tl's "Inner clock": synchronizes signals going to the digital logic
-          // - outgoing clock: synchronizes signals going out
-          // - incoming clock: synchronizes signals coming in
-          val outgoing_clock = serial_tl_clock_node.in.head._1.clock
-          val outgoing_reset = ResetCatchAndSync(outgoing_clock, ctc2tl.module.reset.asBool)
-          val incoming_clock = phit_io.clock_in
-          val incoming_reset = ResetCatchAndSync(incoming_clock, phit_io.reset_in.asBool)
-          phit_io.clock_out := outgoing_clock
-          phit_io.reset_out := outgoing_reset.asAsyncReset
-          val phy = Module(new CreditedSerialPhy(2, phyParams))
-          phy.io.incoming_clock := incoming_clock
-          phy.io.incoming_reset := incoming_reset
-          phy.io.outgoing_clock := outgoing_clock
-          phy.io.outgoing_reset := outgoing_reset
-          phy.io.inner_clock := ctc2tl.module.clock
-          phy.io.inner_reset := ctc2tl.module.reset
-          phy.io.inner_ser(0).in <> ctc2tl.module.io.flit.in
-          phy.io.inner_ser(0).out <> tl2ctc.module.io.flit.out
-          phy.io.inner_ser(1).in <> tl2ctc.module.io.flit.in
-          phy.io.inner_ser(1).out <> ctc2tl.module.io.flit.out
-
-          phy.io.outer_ser <> phit_io.viewAsSupertype(new ValidPhitIO(phyParams.phitWidth))
-          phit_io
+            phy.io.outer_ser <> io.viewAsSupertype(new ValidPhitIO(params.phyParams.get.phitWidth))
+          }
+          case io: DecoupledInternalSyncPhitIO => {
+            val outgoing_clock = ctc_clock_node.in.head._1.clock
+            io.clock_out := outgoing_clock
+            val phy = Module(new DecoupledSerialPhy(2, params.phyParams.get))
+            phy.io.outer_clock := outgoing_clock
+            phy.io.outer_reset := ResetCatchAndSync(outgoing_clock, ctc2tl.module.reset.asBool)
+            phy.io.inner_clock := ctc2tl.module.clock
+            phy.io.inner_reset := ctc2tl.module.reset
+            phy.io.inner_ser(0).in <> ctc2tl.module.io.flit.in
+            phy.io.inner_ser(0).out <> tl2ctc.module.io.flit.out
+            phy.io.inner_ser(1).in <> tl2ctc.module.io.flit.in
+            phy.io.inner_ser(1).out <> ctc2tl.module.io.flit.out
+            phy.io.outer_ser <> io.viewAsSupertype(new DecoupledPhitIO(params.phyParams.get.phitWidth))
+          }
+          case io: DecoupledExternalSyncPhitIO => {
+            val outgoing_clock = io.clock_in
+            val outgoing_reset = ResetCatchAndSync(outgoing_clock, ctc2tl.module.reset.asBool)
+            val phy = Module(new DecoupledSerialPhy(2, params.phyParams.get))
+            phy.io.outer_clock := outgoing_clock
+            phy.io.outer_reset := ResetCatchAndSync(outgoing_clock, ctc2tl.module.reset.asBool)
+            phy.io.inner_clock := ctc2tl.module.clock
+            phy.io.inner_reset := ctc2tl.module.reset
+            phy.io.inner_ser(0).in <> ctc2tl.module.io.flit.in
+            phy.io.inner_ser(0).out <> tl2ctc.module.io.flit.out
+            phy.io.inner_ser(1).in <> tl2ctc.module.io.flit.in
+            phy.io.inner_ser(1).out <> ctc2tl.module.io.flit.out
+            phy.io.outer_ser <> io.viewAsSupertype(new DecoupledPhitIO(params.phyParams.get.phitWidth))
+          }
+          case io: CTCBridgeIO => {
+            io.manager_flit <> tl2ctc.module.io.flit
+            io.client_flit <> ctc2tl.module.io.flit
+          }
         }
+        outer_io
       }}
 
       val outer_io = InModuleBody {
-        val outer_io = if (params.noPhy) IO(new CTCBridgeIO).suggestName(ctc_name) else IO(phyParams.genIO).suggestName(ctc_name)
+        val outer_io = params.phyParams.map(pP => IO(pP.genIO).suggestName(ctc_name)).getOrElse(IO(new CTCBridgeIO).suggestName(ctc_name))
         outer_io <> ctc_outer_io
         outer_io
       }
@@ -158,4 +189,16 @@ trait CanHavePeripheryCTC { this: BaseSubsystem =>
 
 class WithCTC(params: Seq[CTCParams] = Seq(CTCParams())) extends Config((site, here, up) => {
   case CTCKey => params
+})
+
+class WithCTCPhyParams(phyParams: SerialPhyParams = CreditedSourceSyncSerialPhyParams(phitWidth = CTC.OUTER_WIDTH, flitWidth = CTC.INNER_WIDTH, freqMHz = 100, flitBufferSz = 16)) extends Config((site, here, up) => {
+  case CTCKey => up(CTCKey).map(p => p.copy(phyParams = Some(phyParams)))
+})
+
+class WithCTCDecoupledPhy extends Config((site, here, up) => {
+  case CTCKey => up(CTCKey).map(p => p.copy(phyParams = Some(DecoupledInternalSyncSerialPhyParams(phitWidth = CTC.OUTER_WIDTH, flitWidth = CTC.INNER_WIDTH, freqMHz = 100, flitBufferSz = 16))))
+})
+
+class WithNoCTCPhy extends Config((site, here, up) => {
+  case CTCKey => up(CTCKey).map(p => p.copy(phyParams = None))
 })

--- a/src/main/scala/ctc/CTCMem.scala
+++ b/src/main/scala/ctc/CTCMem.scala
@@ -1,0 +1,52 @@
+package testchipip.ctc
+
+import chisel3._
+import chisel3.util._
+import org.chipsalliance.cde.config.{Parameters, Field}
+import freechips.rocketchip.subsystem._
+import freechips.rocketchip.tilelink._
+import freechips.rocketchip.devices.tilelink._
+import freechips.rocketchip.diplomacy._
+import freechips.rocketchip.util._
+import testchipip.serdes.{DecoupledPhitIO, DecoupledSerialPhy}
+import testchipip.ctc._
+
+// A test memory like SerialRAM but for CTC
+// Takes in DecoupledFlitIO, puts it through CTCToTileLink, then connects the TileLink node to TLRAM
+class CTCMem(params: CTCParams)(implicit p: Parameters) extends LazyModule {
+    val beatBytes = 8
+    val ctc2tl = LazyModule(new CTCToTileLink(sourceIds = 1, portId = 0))
+
+    val xbar = TLXbar()
+
+    // Use smaller memory size for testing
+    val testmems = params.offchip.map(address => LazyModule(new TLRAM(address = AddressSet(address.base, 0xFFFFFL), beatBytes = beatBytes) {override lazy val desiredName = "CTCMem"}))
+    testmems.foreach { s => (s.node
+      := TLBuffer()
+      := TLFragmenter(beatBytes, p(CacheBlockBytes), nameSuffix = Some("CTCMem"))
+      := xbar)
+    }
+
+    xbar := ctc2tl.node
+
+    lazy val module = new Impl
+    class Impl extends LazyModuleImp(this) {
+        val io = IO(new Bundle {
+            val ser = new DecoupledPhitIO(CTC.OUTER_WIDTH)
+        })
+
+        val phy = Module(new DecoupledSerialPhy(2, params.phyParams.get))
+        phy.io.outer_clock := clock
+        phy.io.outer_reset := reset
+        phy.io.inner_clock := clock
+        phy.io.inner_reset := reset
+        phy.io.outer_ser <> io.ser
+        phy.io.inner_ser(0).in <> ctc2tl.module.io.flit.in
+        phy.io.inner_ser(1).out <> ctc2tl.module.io.flit.out
+
+        // Tie off unused channels
+        phy.io.inner_ser(1).in.ready := false.B
+        phy.io.inner_ser(0).out.valid := false.B
+        phy.io.inner_ser(0).out.bits := DontCare
+    }
+}

--- a/src/main/scala/ctc/TileLinkToCTC.scala
+++ b/src/main/scala/ctc/TileLinkToCTC.scala
@@ -13,12 +13,17 @@ import org.chipsalliance.cde.config.{Parameters, Field}
 // to outer: sends read and write requests in CTC
 // from outer: receives read and write responses in CTC
 // to inner: sends read and write responses in TL
-class TileLinkToCTC(sinkIds: Int = 1, val beatBytes: Int = 8, baseAddr: BigInt = 0, size: BigInt = ((1L << 10) - 1), val maxBeats: Int = 4)
-                  (implicit p: Parameters) extends LazyModule {
-  val addrSet = AddressSet(baseAddr, size)
+class TileLinkToCTC(
+  sinkIds: Int = 1, 
+  val beatBytes: Int = 8, 
+  val addrRegion: Seq[AddressSet] = Seq(AddressSet(0, ((1L << 10) - 1))), 
+  val maxBeats: Int = 4
+)(implicit p: Parameters) extends LazyModule {
+  val memDevice = new SimpleDevice("ctc-lbwif", Nil)
   val node = TLManagerNode(Seq(TLSlavePortParameters.v1(
     managers = Seq(TLSlaveParameters.v2(
-      address = Seq(addrSet),
+      address = addrRegion,
+      resources = memDevice.reg,
       regionType = RegionType.UNCACHED,
       supports = TLMasterToSlaveTransferSizes(
         putFull = TransferSizes(1, beatBytes*maxBeats), 

--- a/src/main/scala/soc/OffchipBus.scala
+++ b/src/main/scala/soc/OffchipBus.scala
@@ -110,7 +110,7 @@ case class InwardAddressTranslatorParams(
 ) extends AddressTranslatorParams {
   def onchipBase = base
   def size = offset - 1
-  def offchipBase = offset * (chipID + 1)
+  def offchipBase = offset << chipID
 }
 
 case class OutwardAddressTranslatorParams(

--- a/src/main/scala/soc/OffchipBus.scala
+++ b/src/main/scala/soc/OffchipBus.scala
@@ -95,21 +95,53 @@ trait CanHaveSwitchableOffchipBus { this: BaseSubsystem =>
   }
 }
 
-// TODO: Don't use base as region size, better support for more than 2 chiplets
-case class InwardAddressTranslator(blockRange : AddressSet, replicationBase : Option[BigInt] = None)(implicit p: Parameters) extends LazyModule {
-  val module_side = replicationBase.map { base =>
-    val baseRegion   = AddressSet(0, base-1)
-    val replicator   = LazyModule(new RegionReplicator(ReplicatedRegion(baseRegion, baseRegion.widen(base))))
+trait AddressTranslatorParams {
+  def onchipBase: BigInt
+  def size: BigInt
+  def offchipBase: BigInt // This chip's base address in the global range
+  def onchipRange: AddressSet = AddressSet(onchipBase, size) // This chip's onchip (local) address range
+  def offchipRange: AddressSet = AddressSet(offchipBase, size)
+}
+
+case class InwardAddressTranslatorParams(
+  chipID: Int, // Assuming index starts at 0
+  offset: BigInt,
+  base: BigInt = 0x0L // Default Chipyard Base
+) extends AddressTranslatorParams {
+  def onchipBase = base
+  def size = offset - 1
+  def offchipBase = offset * (chipID + 1)
+}
+
+case class OutwardAddressTranslatorParams(
+  onchipAddr: BigInt,
+  offchipAddr: BigInt,
+  size: BigInt
+) extends AddressTranslatorParams {
+  def onchipBase = onchipAddr
+  def offchipBase = offchipAddr
+}
+
+case class AddressTranslator(params: AddressTranslatorParams)(implicit p: Parameters) extends LazyModule {
+  // Create a copy of this chip's onchip address range at a higher base address
+  val module_side = {
+    val replicator = LazyModule(new RegionReplicator(ReplicatedRegion(params.onchipRange, params.onchipRange.widen(params.offchipBase))))
     val prefixSource = BundleBridgeSource[UInt](() => UInt(1.W))
     replicator.prefix := prefixSource
     InModuleBody { prefixSource.bundle := 0.U(1.W) } // prefix is unused for TL uncached, so this is ok
     replicator.node
-  }.getOrElse { TLTempNode() }
+  }
 
-  val bus_side = TLFilter(TLFilter.mSubtract(blockRange))(p)
+  val bus_side = params match { 
+    // Translate up (filter out accesses to the lower range)
+    case OutwardAddressTranslatorParams(_,_,_) => TLFilter(TLFilter.mSubtract(params.onchipRange))(p)
+    // Translate down 
+    case InwardAddressTranslatorParams(_,_,_) => TLFilter(TLFilter.mSubtract(params.offchipRange))(p)
+  }
 
-  def apply(node : TLNode) : TLNode = {
-    node := module_side := bus_side
+  def apply(node : TLNode) : TLNode = params match {
+    case OutwardAddressTranslatorParams(_,_,_) => { node := module_side := bus_side }
+    case InwardAddressTranslatorParams(_,_,_) => { bus_side := module_side := node }
   }
 
   lazy val module = new LazyModuleImp(this) {}


### PR DESCRIPTION
The purpose of this PR is to enable building a "passthrough" IO chiplet within Chipyard

It contributes:
- Target-side address translation (controlled by the type of params)
- An offchip test memory like SerialRAM but for CTC, which enables modeling other chiplets as memory
- Support for a decoupled PHY in CTC
- A bugfix to CTC for incorrect TL beat handling on the tl2ctc side