### PR TITLE
Resolve implicit-width-truncation warnings

### DIFF
--- a/src/main/scala/serdes/Serdes.scala
+++ b/src/main/scala/serdes/Serdes.scala
@@ -21,10 +21,10 @@ class GenericSerializer[T <: Data](t: T, flitWidth: Int) extends Module {
 
   io.in.ready := io.out.ready && beat === 0.U
   io.out.valid := io.in.valid || beat =/= 0.U
-  io.out.bits.flit := Mux(beat === 0.U, io.in.bits.asUInt, data(beat))
+  io.out.bits.flit :<= Mux(beat === 0.U, io.in.bits.asUInt, data(beat)).squeeze
 
   when (io.out.fire) {
-    beat := Mux(beat === (dataBeats-1).U, 0.U, beat + 1.U)
+    beat :<= Mux(beat === (dataBeats-1).U, 0.U, beat + 1.U).squeeze
     when (beat === 0.U) {
       data := io.in.bits.asTypeOf(Vec(dataBeats, UInt(flitWidth.W)))
       data(0) := DontCare // unused, DCE this
@@ -57,7 +57,7 @@ class GenericDeserializer[T <: Data](t: T, flitWidth: Int) extends Module {
   })
 
   when (io.in.fire) {
-    beat := Mux(beat === (dataBeats-1).U, 0.U, beat + 1.U)
+    beat :<= Mux(beat === (dataBeats-1).U, 0.U, beat + 1.U).squeeze
     if (dataBeats > 1) {
       when (beat =/= (dataBeats-1).U) {
         data(beat(log2Ceil(dataBeats-1)-1,0)) := io.in.bits.flit
@@ -85,7 +85,7 @@ class FlitToPhit(flitWidth: Int, phitWidth: Int) extends Module {
   io.out.bits.phit := (if (dataBeats == 1) io.in.bits.flit else Mux(beat === 0.U, io.in.bits.flit, data(beat-1.U)))
 
   when (io.out.fire) {
-    beat := Mux(beat === (dataBeats-1).U, 0.U, beat + 1.U)
+    beat :<= Mux(beat === (dataBeats-1).U, 0.U, beat + 1.U).squeeze
     when (beat === 0.U) {
       data := io.in.bits.asTypeOf(Vec(dataBeats, UInt(phitWidth.W))).tail
     }
@@ -117,7 +117,7 @@ class PhitToFlit(flitWidth: Int, phitWidth: Int) extends Module {
   io.out.bits.flit := (if (dataBeats == 1) io.in.bits.phit else Cat(io.in.bits.phit, data.asUInt))
 
   when (io.in.fire) {
-    beat := Mux(beat === (dataBeats-1).U, 0.U, beat + 1.U)
+    beat :<= Mux(beat === (dataBeats-1).U, 0.U, beat + 1.U).squeeze
     if (dataBeats > 1) {
       when (beat =/= (dataBeats-1).U) {
         data(beat) := io.in.bits.phit

--- a/src/main/scala/serdes/TLChannelCompactor.scala
+++ b/src/main/scala/serdes/TLChannelCompactor.scala
@@ -101,7 +101,7 @@ abstract class TLChannelFromBeat[T <: TLChannel](gen: => T, nameSuffix: Option[S
   assign(const, const_fields)
   assign(io.beat.bits.payload, body_fields)
 
-  when (io.beat.fire && io.beat.bits.head) { is_const := false.B; const_reg := io.beat.bits.payload }
+  when (io.beat.fire && io.beat.bits.head) { is_const := false.B; const_reg :<= io.beat.bits.payload.squeeze }
   when (io.beat.fire && io.beat.bits.tail) { is_const := true.B }
 }
 

--- a/src/main/scala/serdes/TLSerdes.scala
+++ b/src/main/scala/serdes/TLSerdes.scala
@@ -74,15 +74,18 @@ class TLSerdesser(
 
     io.debug.ser_busy := out_sers.map(_.io.busy).orR
 
+    private def wireProtocol[T <: TLChannel](c: DecoupledIO[T], b: TLChannelFromBeat[T]): TLChannelFromBeat[T] = {
+      c :<>= b.io.protocol.squeezeAll
+      b
+    }
     val in_channels = Seq(
-      (client_tl.e,  Module(new TLEFromBeat(mergedParams, nameSuffix))),
-      (manager_tl.d, Module(new TLDFromBeat(mergedParams, nameSuffix))),
-      (client_tl.c,  Module(new TLCFromBeat(mergedParams, nameSuffix))),
-      (manager_tl.b, Module(new TLBFromBeat(mergedParams, nameSuffix))),
-      (client_tl.a,  Module(new TLAFromBeat(mergedParams, nameSuffix)))
+      wireProtocol(client_tl.e,  Module(new TLEFromBeat(mergedParams, nameSuffix))),
+      wireProtocol(manager_tl.d, Module(new TLDFromBeat(mergedParams, nameSuffix))),
+      wireProtocol(client_tl.c,  Module(new TLCFromBeat(mergedParams, nameSuffix))),
+      wireProtocol(manager_tl.b, Module(new TLBFromBeat(mergedParams, nameSuffix))),
+      wireProtocol(client_tl.a,  Module(new TLAFromBeat(mergedParams, nameSuffix)))
     )
-    val in_desers = in_channels.zipWithIndex.map { case ((c,b),i) =>
-      c <> b.io.protocol
+    val in_desers = in_channels.zipWithIndex.map { case (b,i) =>
       val des = Module(new GenericDeserializer(b.io.beat.bits.cloneType, flitWidth)).suggestName(s"des_$i")
       des.io.in <> io.ser(i).in
       b.io.beat <> des.io.out


### PR DESCRIPTION
firtool-1.154.0 and later warn on all implicit width truncations (https://github.com/llvm/circt/pull/10621). These width truncations were flagged in stock Chipyard builds.

For all width truncations, use the equivalent `Connectable` operator (`:<=` or `:<>=`), along with `.squeeze`/`.squeezeAll`. This has the same behavior as the original `:=`/`<>` connections, since those truncate when the producer in a connection is wider than the consumer.

Note that in `TLSerdes.scala`, we needed the `wireProtocol` helper function. The Connectable operators require that the types being connected are structurally type-equivalent. When the five different TL bundles were placed in the `Seq`, their types were erased inside the iteration over `in_channels`. So we connect the `io.protocol` output to the appropriate TL bundle with `wireProtocol` before those types get erased.